### PR TITLE
Problem: impossible to listen for committed entities

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/ClassEntitySubscriber.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/ClassEntitySubscriber.java
@@ -1,0 +1,25 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing;
+
+/**
+ * {@link EntitySubscriber} that subscribes to all entities that are inherited from
+ * a certain class.
+ * @param <T>
+ */
+public class ClassEntitySubscriber<T extends Entity> implements EntitySubscriber<T> {
+
+    private final Class<T> klass;
+
+    public ClassEntitySubscriber(Class<T> klass) {
+        this.klass = klass;
+    }
+
+    @Override public boolean matches(T entity) {
+        return klass.isAssignableFrom(entity.getClass());
+    }
+
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/CommandConsumer.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/CommandConsumer.java
@@ -7,8 +7,13 @@ package com.eventsourcing;
 
 import com.google.common.util.concurrent.Service;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 public interface CommandConsumer extends Service {
-    <T, C extends Command<T>> CompletableFuture<T> publish(C command);
+    default <T, C extends Command<T>> CompletableFuture<T> publish(C command) {
+        return publish(command, Collections.emptyList());
+    }
+    <T, C extends Command<T>> CompletableFuture<T> publish(C command, Collection<EntitySubscriber> subscribers);
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/DispatchingCommandConsumer.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/DispatchingCommandConsumer.java
@@ -14,10 +14,7 @@ import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.AbstractService;
 import com.google.common.util.concurrent.ServiceManager;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 
@@ -50,7 +47,7 @@ public class DispatchingCommandConsumer extends AbstractService implements Comma
     }
 
     @Override
-    public <T, C extends Command<T>> CompletableFuture<T> publish(C command) {
+    public <T, C extends Command<T>> CompletableFuture<T> publish(C command, Collection<EntitySubscriber> subscribers) {
         UUID uuid = command.uuid();
         HashCode hashCode = HashCode.fromBytes(Bytes.concat(Longs.toByteArray(uuid.getMostSignificantBits()),
                                                             Longs.toByteArray(uuid.getLeastSignificantBits())));

--- a/eventsourcing-core/src/main/java/com/eventsourcing/EntitySubscriber.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/EntitySubscriber.java
@@ -1,0 +1,59 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing;
+
+import java.util.stream.Stream;
+
+/**
+ * EntitySubscriber allows to listen to entities (commands and events)
+ * once they are committed. Use {@link Repository#addEntitySubscriber(EntitySubscriber)}
+ * to add an entity subscriber.
+ *
+ * <p/>
+ *
+ * When an event or a command are being processed, repository will
+ * use {@link EntitySubscriber#matches(Entity)} to determine whether
+ * the entity is being subscribed to. Please not that it will store
+ * entity UUID until the entire command is committed, so if your command
+ * generates an extremely high number of events, you might experience
+ * significant memory usage penalty.
+ * Once a command is processed and committed, {@link EntitySubscriber#accept(Stream)}
+ * is invoked with a stream of entity handles.
+ * By default, {@link EntitySubscriber#accept(Stream)} invokes {@link EntitySubscriber#onEntity(EntityHandle)}
+ * for every entity handle.
+ *
+ * <p/>
+ *
+ * Most common entity subscriber is a {@link ClassEntitySubscriber}
+ * @param <T>
+ */
+public interface EntitySubscriber<T extends Entity> {
+    /**
+     * Defines a predicate for matching entities
+     * @param entity
+     * @return true if the entity should be returned
+     */
+    default boolean matches(T entity) {
+        return true;
+    }
+
+    /**
+     * Used by {@link #accept(Stream)} to be invoked for every entity handle.
+     * Does nothing by default.
+     * @param entity
+     */
+    default void onEntity(EntityHandle<T> entity) {}
+
+    /**
+     * This method is invoked once the command is being committed and all relevant entities
+     * have been collected. It provides a default implementation that invokes {@link #onEntity(EntityHandle)}
+     * for every entity handle.
+     * @param entityStream
+     */
+    default void accept(Stream<EntityHandle<T>> entityStream) {
+        entityStream.forEach(this::onEntity);
+    }
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/Repository.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/Repository.java
@@ -116,6 +116,18 @@ public interface Repository extends Service {
     void removeEventSetProvider(EventSetProvider provider);
 
     /**
+     * Adds an entity subscriber
+     * @param subscriber
+     */
+    void addEntitySubscriber(EntitySubscriber subscriber);
+
+    /**
+     * Removes an entity subscriber
+     * @param subscriber
+     */
+    void removeEntitySubscriber(EntitySubscriber subscriber);
+
+    /**
      * Returns a set of commands discovered or configured
      * with this repository
      *

--- a/eventsourcing-core/src/main/java/com/eventsourcing/RepositoryImpl.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/RepositoryImpl.java
@@ -39,6 +39,8 @@ public class RepositoryImpl extends AbstractService implements Repository, Repos
     private LockProvider lockProvider;
     private CommandConsumer commandConsumer;
 
+    private List<EntitySubscriber> entitySubscribers = new ArrayList<>();
+
     @Activate
     protected void activate(ComponentContext ctx) {
         if (!isRunning()) {
@@ -147,6 +149,17 @@ public class RepositoryImpl extends AbstractService implements Repository, Repos
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     @Override
+    public void addEntitySubscriber(EntitySubscriber subscriber) {
+        entitySubscribers.add(subscriber);
+    }
+
+    @Override
+    public void removeEntitySubscriber(EntitySubscriber subscriber) {
+        entitySubscribers.remove(subscriber);
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    @Override
     public void addEventSetProvider(EventSetProvider provider) {
         final Set<Class<? extends Event>> newEvents = provider.getEvents();
         Runnable runnable = () -> {
@@ -190,7 +203,7 @@ public class RepositoryImpl extends AbstractService implements Repository, Repos
 
     @Override
     public <T extends Command<C>, C> CompletableFuture<C> publish(T command) {
-        return this.commandConsumer.publish(command);
+        return this.commandConsumer.publish(command, entitySubscribers);
     }
 
 

--- a/eventsourcing-h2/src/main/java/com/eventsourcing/h2/MVStoreJournal.java
+++ b/eventsourcing-h2/src/main/java/com/eventsourcing/h2/MVStoreJournal.java
@@ -247,11 +247,11 @@ public class MVStoreJournal extends AbstractService implements Journal, JournalM
             txHashCommands.put(hashBuffer.array(), true);
             txCommandHashes.put(command.uuid(), commandLayout.getHash());
 
-            listener.onCommit();
-
             tx.prepare();
             tx.commit();
 
+            listener.onCommit();
+            
             return count;
         } catch (Exception e) {
             tx.rollback();


### PR DESCRIPTION
In event sourcing, there are many cases when events/commands
need to be listened upon their serialization to ensure proactive
processing (aggregate root listeners, etc.), as opposed to lazy
index-based processing at a later point in time.

Solution: introduce EntitySubscriber interface that will receive
entities once they are committed.