### PR TITLE
Problem: EntityHandle leaked implementation details

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/DisruptorCommandConsumer.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/DisruptorCommandConsumer.java
@@ -98,7 +98,7 @@ public class DisruptorCommandConsumer extends AbstractService implements Command
         public void onEvent(Event event) {
             IndexedCollection<EntityHandle<Event>> coll = indexEngine
                     .getIndexedCollection((Class<Event>) event.getClass());
-            coll.add(new EntityHandle<>(journal, event.uuid()));
+            coll.add(new JournalEntityHandle<>(journal, event.uuid()));
             disruptorEvent.getEntitySubscribers().stream()
                     .filter(s -> s.matches(event))
                     .forEach(s -> subscriptions.get(s).add(event.uuid()));
@@ -108,13 +108,13 @@ public class DisruptorCommandConsumer extends AbstractService implements Command
         public void onCommit() {
             IndexedCollection<EntityHandle<Command<?>>> coll = indexEngine
                     .getIndexedCollection((Class<Command<?>>) command.getClass());
-            EntityHandle<Command<?>> commandHandle = new EntityHandle<>(journal, command.uuid());
+            EntityHandle<Command<?>> commandHandle = new JournalEntityHandle<>(journal, command.uuid());
             coll.add(commandHandle);
             subscriptions.entrySet().stream()
                     .forEach(entry -> entry.getKey()
                                            .accept(entry.getValue()
                                                         .stream()
-                                                        .map(uuid -> new EntityHandle<>(journal, uuid))));
+                                                        .map(uuid -> new JournalEntityHandle<>(journal, uuid))));
             disruptorEvent.getEntitySubscribers().stream()
                     .filter(s -> s.matches(command))
                     .forEach(s -> s.accept(Stream.of(commandHandle)));

--- a/eventsourcing-core/src/main/java/com/eventsourcing/EntityHandle.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/EntityHandle.java
@@ -5,27 +5,14 @@
  */
 package com.eventsourcing;
 
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 import java.util.Optional;
-import java.util.UUID;
 
 /**
  * EntityHandle is a "lazy loading" handle for {@link Entity}
  *
  * @param <T>
  */
-public class EntityHandle<T extends Entity> {
-    @Getter @Accessors(fluent = true)
-    private final UUID uuid;
-    private final Journal journal;
-
-    public EntityHandle(Journal journal, UUID uuid) {
-        this.journal = journal;
-        this.uuid = uuid;
-    }
-
+public interface EntityHandle<T extends Entity> {
     /**
      * Returns an optional value of the referenced entity (empty if an entity specified by a given
      * UUID can't be found). When the entity is expected to be found, {@link #get()}
@@ -33,9 +20,7 @@ public class EntityHandle<T extends Entity> {
      *
      * @return
      */
-    public Optional<T> getOptional() {
-        return journal.get(uuid);
-    }
+    Optional<T> getOptional();
 
     /**
      * Returns the referenced entity
@@ -43,7 +28,9 @@ public class EntityHandle<T extends Entity> {
      * @return
      * @throws java.util.NoSuchElementException if the entity wasn't found
      */
-    public T get() {
+    default T get() {
         return getOptional().get();
     }
+
+    java.util.UUID uuid();
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/JournalEntityHandle.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/JournalEntityHandle.java
@@ -1,0 +1,31 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing;
+
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Entity handle implementation that uses journal to access the entity
+ * @param <T>
+ */
+public class JournalEntityHandle<T extends Entity> implements EntityHandle<T> {
+    @Getter @Accessors(fluent = true)
+    private final UUID uuid;
+    private final Journal journal;
+
+    public JournalEntityHandle(Journal journal, UUID uuid) {
+        this.journal = journal;
+        this.uuid = uuid;
+    }
+
+    @Override public Optional<T> getOptional() {
+        return journal.get(uuid);
+    }
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/MemoryJournal.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/MemoryJournal.java
@@ -129,19 +129,16 @@ public class MemoryJournal extends AbstractService implements Journal {
 
     @Override
     public synchronized <T extends Command<?>> CloseableIterator<EntityHandle<T>> commandIterator(Class<T> klass) {
-        return new CloseableWrappingIterator<>(commands.values().stream().
-                filter(command -> klass.isAssignableFrom(command.getClass())).
-                                                               map(command -> new EntityHandle<T>(this, command.uuid()))
-                                                       .
-                                                               iterator());
+        return new CloseableWrappingIterator<>(commands.values().stream()
+                .filter(command -> klass.isAssignableFrom(command.getClass()))
+                .map(command -> (EntityHandle<T>) new JournalEntityHandle<T>(this, command.uuid())).iterator());
     }
 
     @Override
     public synchronized <T extends Event> CloseableIterator<EntityHandle<T>> eventIterator(Class<T> klass) {
-        return new CloseableWrappingIterator<>(events.values().stream().
-                filter(event -> klass.isAssignableFrom(event.getClass())).
-                                                             map(event -> new EntityHandle<T>(this, event.uuid())).
-                                                             iterator());
+        return new CloseableWrappingIterator<>(events.values().stream()
+                 .filter(event -> klass.isAssignableFrom(event.getClass()))
+                 .map(event -> (EntityHandle<T>) new JournalEntityHandle<T>(this, event.uuid())).iterator());
     }
 
     @Override

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/SimpleAttribute.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/SimpleAttribute.java
@@ -7,11 +7,12 @@ package com.eventsourcing.index;
 
 import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
+import com.eventsourcing.JournalEntityHandle;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
  * An extension of {@link com.googlecode.cqengine.attribute.SimpleAttribute} that hides
- * the unnecessary complexity of using {@link EntityHandle}
+ * the unnecessary complexity of using {@link JournalEntityHandle}
  *
  * @param <O>
  * @param <A>

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexEngineTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexEngineTest.java
@@ -103,7 +103,7 @@ public abstract class IndexEngineTest<T extends IndexEngine> {
             }
         });
         Event event = events.get(0);
-        coll.add(new EntityHandle<>(journal, event.uuid()));
+        coll.add(new JournalEntityHandle<>(journal, event.uuid()));
 
         EntityHandle<TestEvent> handle = coll.retrieve(equal(TestEvent.ATTR, "test")).uniqueResult();
         assertTrue(handle.getOptional().isPresent());

--- a/eventsourcing-h2/src/main/java/com/eventsourcing/h2/MVStoreJournal.java
+++ b/eventsourcing-h2/src/main/java/com/eventsourcing/h2/MVStoreJournal.java
@@ -449,7 +449,7 @@ public class MVStoreJournal extends AbstractService implements Journal, JournalM
         public EntityHandle<T> apply(byte[] bytes, Boolean aBoolean) {
             ByteBuffer buffer = ByteBuffer.wrap(bytes);
             UUID uuid = new UUID(buffer.getLong(hash.length), buffer.getLong(hash.length + 8));
-            return new EntityHandle<>(MVStoreJournal.this, uuid);
+            return new JournalEntityHandle<>(MVStoreJournal.this, uuid);
         }
     }
 


### PR DESCRIPTION
Its public interface exposed an implementation detail of using
Journals for accessing entities.

Solution: extract an interface and move existing implementation
to JournalEntityHandler