### PR TITLE
Problem: cqengine 2.5.0 has been superseded

### DIFF
--- a/eventsourcing-core/build.gradle
+++ b/eventsourcing-core/build.gradle
@@ -12,6 +12,6 @@ dependencies {
     compile 'com.lmax:disruptor:3.3.4'
 
     // Indexing
-    compile 'com.googlecode.cqengine:cqengine:2.5.0'
+    compile 'com.googlecode.cqengine:cqengine:2.6.0'
 
 }


### PR DESCRIPTION
Solution: upgrade to 2.6.0