### PR TITLE
Problem: slow MVStoreJournal

### DIFF
--- a/eventsourcing-h2/build.gradle
+++ b/eventsourcing-h2/build.gradle
@@ -10,4 +10,7 @@ dependencies {
     // Useful utilities
     compile 'com.google.guava:guava:19.0'
 
+    // Caching
+    compile 'com.github.ben-manes.caffeine:caffeine:2.3.0'
+
 }

--- a/eventsourcing-h2/src/main/java/com/eventsourcing/h2/ByteBufferDataType.java
+++ b/eventsourcing-h2/src/main/java/com/eventsourcing/h2/ByteBufferDataType.java
@@ -1,0 +1,52 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.h2;
+
+import org.h2.mvstore.WriteBuffer;
+import org.h2.mvstore.type.DataType;
+
+import java.nio.ByteBuffer;
+
+public class ByteBufferDataType implements DataType {
+    @Override public int compare(Object a, Object b) {
+        if (a instanceof ByteBuffer && b instanceof ByteBuffer) {
+            return ((ByteBuffer) a).compareTo((ByteBuffer) b);
+        } else {
+            throw new RuntimeException("ByteBuffers expected");
+        }
+    }
+
+    @Override public int getMemory(Object obj) {
+        return ((ByteBuffer) obj).limit() - ((ByteBuffer) obj).position();
+    }
+
+    @Override public void write(WriteBuffer buff, Object obj) {
+        ByteBuffer o = (ByteBuffer) obj;
+        int sz = o.limit();
+        if (sz == 0) {
+            sz = o.capacity();
+        }
+        buff.putInt(sz - o.position());
+        buff.put(o);
+    }
+
+    @Override public void write(WriteBuffer buff, Object[] obj, int len, boolean key) {
+        for (Object o : obj) {
+            write(buff, o);
+        }
+    }
+
+    @Override public Object read(ByteBuffer buff) {
+        int sz = buff.getInt();
+        return buff.slice().limit(sz);
+    }
+
+    @Override public void read(ByteBuffer buff, Object[] obj, int len, boolean key) {
+        for (int i = 0; i < obj.length; i++) {
+            obj[i] = read(buff);
+        }
+    }
+}

--- a/eventsourcing-h2/src/test/java/com/eventsourcing/h2/ByteBufferDataTypeTest.java
+++ b/eventsourcing-h2/src/test/java/com/eventsourcing/h2/ByteBufferDataTypeTest.java
@@ -1,0 +1,57 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.h2;
+
+import org.h2.mvstore.WriteBuffer;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.testng.Assert.*;
+
+public class ByteBufferDataTypeTest {
+    @Test
+    public void testCompare() throws Exception {
+        ByteBuffer b1 = ByteBuffer.allocate(1);
+        ByteBuffer b2 = ByteBuffer.allocate(1);
+        b1.put((byte) 0);
+        b2.put((byte) 1);
+        assertEquals(new ByteBufferDataType().compare(b1, b2), b1.compareTo(b2));
+    }
+
+    @Test
+    public void testGetMemory() throws Exception {
+        ByteBuffer b = ByteBuffer.allocate(100);
+        b.position(1);
+        b.limit(50);
+        assertEquals(new ByteBufferDataType().getMemory(b), 49);
+    }
+
+    @Test
+    public void testWrite() throws Exception {
+        ByteBuffer b = ByteBuffer.allocate(100);
+        b.position(1);
+        b.limit(50);
+        b.putInt(100);
+        b.position(1);
+        WriteBuffer writeBuffer = new WriteBuffer();
+        ByteBufferDataType byteBufferDataType = new ByteBufferDataType();
+        byteBufferDataType.write(writeBuffer, b);
+        ByteBuffer rb = writeBuffer.getBuffer();
+        rb.rewind();
+        ByteBuffer b1 = (ByteBuffer) byteBufferDataType.read(rb);
+        assertEquals(b1.limit(), 49);
+        assertEquals(rb.getInt(), 100);
+
+        rb.rewind();
+
+        ByteBuffer[] byteBuffers = new ByteBuffer[1];
+        byteBufferDataType.read(rb, byteBuffers, 1, false);
+
+        assertEquals(byteBuffers[0].getInt(), 100);
+    }
+
+}


### PR DESCRIPTION
Solution: implement numerous optimizations.

1. Reduce the amount of ByteBuffer allocations
2. Implement ByteBuffer MVStore serialization
3. Use transactional map's tryPut() instead of put()
   as it doesn't read the original value