### PR TITLE
Problem: Unknown type handler fingerprint loses type information

### DIFF
--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/types/UnknownTypeHandler.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/types/UnknownTypeHandler.java
@@ -32,7 +32,7 @@ public class UnknownTypeHandler implements TypeHandler {
 
     @Override
     public byte[] getFingerprint() {
-        return "Unknown".getBytes();
+        return layout.getHash();
     }
 
     @Override @SneakyThrows


### PR DESCRIPTION
Solution: include it in the fingerprint