### PR TITLE
Problem: command's timestamp can't be specified before publishing

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/CommandConsumer.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/CommandConsumer.java
@@ -7,6 +7,7 @@
  */
 package com.eventsourcing;
 
+import com.eventsourcing.hlc.HybridTimestamp;
 import com.google.common.util.concurrent.Service;
 
 import java.util.Collection;
@@ -18,4 +19,6 @@ public interface CommandConsumer extends Service {
         return publish(command, Collections.emptyList());
     }
     <T, C extends Command<T>> CompletableFuture<T> publish(C command, Collection<EntitySubscriber> subscribers);
+
+    HybridTimestamp getTimestamp();
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/DispatchingCommandConsumer.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/DispatchingCommandConsumer.java
@@ -7,6 +7,7 @@
  */
 package com.eventsourcing;
 
+import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.hlc.PhysicalTimeProvider;
 import com.eventsourcing.index.IndexEngine;
 import com.google.common.hash.HashCode;
@@ -55,6 +56,10 @@ public class DispatchingCommandConsumer extends AbstractService implements Comma
                                                             Longs.toByteArray(uuid.getLeastSignificantBits())));
         int bucket = Hashing.consistentHash(hashCode, consumers.size());
         return consumers.get(bucket).publish(command);
+    }
+
+    @Override public HybridTimestamp getTimestamp() {
+        return consumers.get(0).getTimestamp();
     }
 
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/DisruptorCommandConsumer.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/DisruptorCommandConsumer.java
@@ -78,6 +78,7 @@ public class DisruptorCommandConsumer extends AbstractService implements Command
     private RingBuffer<CommandEvent> ringBuffer;
     private Disruptor<CommandEvent> disruptor;
 
+    @Getter
     private HybridTimestamp timestamp;
 
     private static class JournalListener implements Journal.Listener {
@@ -201,9 +202,13 @@ public class DisruptorCommandConsumer extends AbstractService implements Command
     }
 
     private void timestamp(CommandEvent event, long sequence, boolean endOfBatch) throws Exception {
-        timestamp.update();
         Command command = event.getCommand();
-        command.timestamp(timestamp.clone());
+        if (command.timestamp() == null) {
+            timestamp.update();
+            command.timestamp(timestamp.clone());
+        } else {
+            timestamp.update(timestamp.clone());
+        }
     }
 
     private void journal(CommandEvent event) throws Exception {

--- a/eventsourcing-core/src/main/java/com/eventsourcing/Repository.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/Repository.java
@@ -7,6 +7,7 @@
  */
 package com.eventsourcing;
 
+import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.hlc.PhysicalTimeProvider;
 import com.eventsourcing.index.IndexEngine;
@@ -187,4 +188,9 @@ public interface Repository extends Service {
                                                                 QueryOptions queryOptions) {
         return getIndexEngine().getIndexedCollection(klass).retrieve(query, queryOptions);
     }
+
+    /**
+     * @return Repository's current timestamp
+     */
+    HybridTimestamp getTimestamp();
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/RepositoryImpl.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/RepositoryImpl.java
@@ -7,6 +7,7 @@
  */
 package com.eventsourcing;
 
+import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.hlc.PhysicalTimeProvider;
 import com.eventsourcing.index.IndexEngine;
 import com.google.common.util.concurrent.AbstractService;
@@ -206,6 +207,10 @@ public class RepositoryImpl extends AbstractService implements Repository, Repos
     @Override
     public <T extends Command<C>, C> CompletableFuture<C> publish(T command) {
         return this.commandConsumer.publish(command, entitySubscribers);
+    }
+
+    @Override public HybridTimestamp getTimestamp() {
+        return commandConsumer.getTimestamp();
     }
 
 


### PR DESCRIPTION
This is useful both for disconnected systems and testing

Solution: only timestamp a command if it doesn't have a timestamp already