### PR TITLE
Problem: impossible to timestamp events before publishing a command

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/MemoryJournal.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/MemoryJournal.java
@@ -195,8 +195,12 @@ public class MemoryJournal extends AbstractService implements Journal {
         @Override
         @SneakyThrows
         public synchronized void accept(Event event) {
-            ts.update();
-            event.timestamp(ts.clone());
+            if (event.timestamp() == null) {
+                ts.update();
+                event.timestamp(ts.clone());
+            } else {
+                ts.update(event.timestamp().clone());
+            }
 
             Layout<Event> layout = new Layout<>((Class<Event>) event.getClass());
             Serializer<Event> serializer = new Serializer<>(layout);

--- a/eventsourcing-h2/src/main/java/com/eventsourcing/h2/MVStoreJournal.java
+++ b/eventsourcing-h2/src/main/java/com/eventsourcing/h2/MVStoreJournal.java
@@ -502,8 +502,13 @@ public class MVStoreJournal extends AbstractService implements Journal, JournalM
         @Override
         @SneakyThrows
         public void accept(Event event) {
-            ts.update();
-            event.timestamp(ts.clone());
+
+            if (event.timestamp() == null) {
+                ts.update();
+                event.timestamp(ts.clone());
+            } else {
+                ts.update(event.timestamp().clone());
+            }
 
             Layout layout = layoutsByClass.get(event.getClass().getName());
 


### PR DESCRIPTION
This is useful for testing and disconnected systems

Solution: similarly to commands, event's timestamp will be overriden
only if it doesn't have one.

Also, this changes the behaviour of the repository. Before, the timestamp
of the repository was the timestamp of the last command. Now, it's the
timestamp of the last command's last event.