### PR TITLE
Problem: Indexing.getAttribute silently fails if the property was not found

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/Indexing.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/Indexing.java
@@ -12,6 +12,7 @@ import com.eventsourcing.annotations.Index;
 import lombok.SneakyThrows;
 import org.javatuples.Pair;
 
+import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
@@ -34,9 +35,13 @@ public class Indexing {
         Stream<Pair<Index, Attribute>> stream = StreamSupport
                 .stream(Spliterators.spliteratorUnknownSize(IndexEngine.getIndexableAttributes(klass).iterator(),
                                                             Spliterator.IMMUTABLE), false);
-        return (Attribute<O, A>) stream
-                .filter(p -> p.getValue1().getAttributeName().equals(name)).findFirst()
-                .map(Pair::getValue1)
-                .orElse(null);
+        try {
+            return (Attribute<O, A>) stream
+                    .filter(p -> p.getValue1().getAttributeName().equals(name)).findFirst()
+                    .map(Pair::getValue1)
+                    .get();
+        } catch (NoSuchElementException e) {
+            throw new RuntimeException("Attribute " + name + " can't be found on class " + klass.getName());
+        }
     }
 }

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexingTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexingTest.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.index;
+
+import org.testng.annotations.Test;
+
+public class IndexingTest {
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void wrongReference() {
+        Indexing.getAttribute(getClass(), "someProperty");
+    }
+
+}


### PR DESCRIPTION
This is a bad behaviour because it obscures the problem and it can't be found easily.

Solution: throw an exception when the property was not found