### PR TITLE
Problem: Repository.create() uses global NTP servers by default

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/Repository.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/Repository.java
@@ -43,7 +43,7 @@ public interface Repository extends Service {
      */
     static Repository create() throws Exception {
         RepositoryImpl repository = new RepositoryImpl();
-        PhysicalTimeProvider timeProvider = new NTPServerTimeProvider();
+        PhysicalTimeProvider timeProvider = new NTPServerTimeProvider(new String[]{"localhost"});
         repository.setPhysicalTimeProvider(timeProvider);
         LockProvider lockProvider = new MemoryLockProvider();
         repository.setLockProvider(lockProvider);


### PR DESCRIPTION
Frequent time sync fetches an IP ban

Solution: revert to localhost by default