### PR TITLE
Problem: Entity, Command and Event classes constrain the class hierarchy

### DIFF
--- a/docs/core_concepts/command.md
+++ b/docs/core_concepts/command.md
@@ -5,7 +5,7 @@ Command is a request for changes in the domain. Unlike an [event](event.md), it 
 Defining a command is pretty straightforward, through subclassing `Command<T>`:
 
 ```java
-public class CreateUser extends Command<User> {
+public class CreateUser extends StandardCommand<User> {
   @Getter @Setter
   private String email;
 }
@@ -26,7 +26,7 @@ A more important part of any command is being able to generate events. This is d
 
 ```java
 @Override
-public Stream<Event> events(Repository repository) {
+public Stream<? extends Event> events(Repository repository) {
   return Stream.of(new UserCreated().setEmail(email));
 }
 ```

--- a/docs/core_concepts/event.md
+++ b/docs/core_concepts/event.md
@@ -7,7 +7,7 @@ Defining an event is quite similar to command, by subclassing `Event`:
 
 
 ```java
-public class UserCreated extends Event {
+public class UserCreated extends StandardEvent {
   @Getter @Setter
   private String email;
 }

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Deleted.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Deleted.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.cep.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Attribute;
@@ -18,8 +18,8 @@ import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import org.unprotocols.coss.RFC;
 import org.unprotocols.coss.Draft;
+import org.unprotocols.coss.RFC;
 
 import java.util.UUID;
 
@@ -29,7 +29,7 @@ import java.util.UUID;
 @Accessors(fluent = true)
 @Draft @RFC(url = "http://rfc.eventsourcing.com/spec:3/CEP")
 @LayoutName("http://rfc.eventsourcing.com/spec:3/CEP/#Deleted")
-public class Deleted extends Event {
+public class Deleted extends StandardEvent {
     @Getter(onMethod = @__(@Index)) @Setter
     UUID reference;
 

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/DescriptionChanged.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/DescriptionChanged.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.cep.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
@@ -29,7 +29,7 @@ import static com.eventsourcing.index.IndexEngine.IndexFeature.*;
 @Accessors(fluent = true)
 @Draft @RFC(url = "http://rfc.eventsourcing.com/spec:3/CEP")
 @LayoutName("http://rfc.eventsourcing.com/spec:3/CEP/#DescriptionChanged")
-public class DescriptionChanged extends Event {
+public class DescriptionChanged extends StandardEvent {
     @Getter @Setter
     UUID reference;
     @Getter @Setter

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/NameChanged.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/NameChanged.java
@@ -7,12 +7,11 @@
  */
 package com.eventsourcing.cep.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
 import com.eventsourcing.layout.LayoutName;
-import com.google.common.primitives.UnsignedLongs;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Getter;
 import lombok.Setter;
@@ -22,9 +21,7 @@ import org.unprotocols.coss.RFC;
 
 import java.util.UUID;
 
-import static com.eventsourcing.index.IndexEngine.IndexFeature.EQ;
-import static com.eventsourcing.index.IndexEngine.IndexFeature.GT;
-import static com.eventsourcing.index.IndexEngine.IndexFeature.LT;
+import static com.eventsourcing.index.IndexEngine.IndexFeature.*;
 
 /**
  * This event signifies the name change for a referenced instance.
@@ -32,7 +29,7 @@ import static com.eventsourcing.index.IndexEngine.IndexFeature.LT;
 @Accessors(fluent = true)
 @Draft @RFC(url = "http://rfc.eventsourcing.com/spec:3/CEP")
 @LayoutName("http://rfc.eventsourcing.com/spec:3/CEP/#NameChanged")
-public class NameChanged extends Event {
+public class NameChanged extends StandardEvent {
     @Getter @Setter
     UUID reference;
     @Getter @Setter

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Undeleted.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Undeleted.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.cep.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Attribute;
@@ -18,8 +18,8 @@ import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import org.unprotocols.coss.RFC;
 import org.unprotocols.coss.Draft;
+import org.unprotocols.coss.RFC;
 
 import java.util.UUID;
 
@@ -29,7 +29,7 @@ import java.util.UUID;
 @Accessors(fluent = true)
 @Draft @RFC(url = "http://rfc.eventsourcing.com/spec:3/CEP")
 @LayoutName("http://rfc.eventsourcing.com/spec:3/CEP/#Undeleted")
-public class Undeleted extends Event {
+public class Undeleted extends StandardEvent {
     @Getter(onMethod = @__(@Index)) @Setter
     UUID deleted;
 

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/protocols/DeletedProtocol.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/protocols/DeletedProtocol.java
@@ -10,18 +10,15 @@ package com.eventsourcing.cep.protocols;
 import com.eventsourcing.EntityHandle;
 import com.eventsourcing.Protocol;
 import com.eventsourcing.cep.events.Deleted;
-import com.eventsourcing.cep.events.NameChanged;
 import com.eventsourcing.cep.events.Undeleted;
 import com.googlecode.cqengine.query.option.EngineThresholds;
 import com.googlecode.cqengine.resultset.ResultSet;
-import org.unprotocols.coss.RFC;
 import org.unprotocols.coss.Draft;
+import org.unprotocols.coss.RFC;
 
-import java.util.Date;
 import java.util.Optional;
 
 import static com.googlecode.cqengine.query.QueryFactory.*;
-import static com.googlecode.cqengine.query.QueryFactory.threshold;
 
 @Draft @RFC(url = "http://rfc.eventsourcing.com/spec:3/CEP")
 public interface DeletedProtocol extends Protocol {

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/protocols/DescriptionProtocol.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/protocols/DescriptionProtocol.java
@@ -12,8 +12,8 @@ import com.eventsourcing.Protocol;
 import com.eventsourcing.cep.events.DescriptionChanged;
 import com.googlecode.cqengine.query.option.EngineThresholds;
 import com.googlecode.cqengine.resultset.ResultSet;
-import org.unprotocols.coss.RFC;
 import org.unprotocols.coss.Draft;
+import org.unprotocols.coss.RFC;
 
 import static com.googlecode.cqengine.query.QueryFactory.*;
 

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/protocols/NameProtocol.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/protocols/NameProtocol.java
@@ -12,8 +12,8 @@ import com.eventsourcing.Protocol;
 import com.eventsourcing.cep.events.NameChanged;
 import com.googlecode.cqengine.query.option.EngineThresholds;
 import com.googlecode.cqengine.resultset.ResultSet;
-import org.unprotocols.coss.RFC;
 import org.unprotocols.coss.Draft;
+import org.unprotocols.coss.RFC;
 
 import static com.googlecode.cqengine.query.QueryFactory.*;
 

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DeletedProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DeletedProtocolTest.java
@@ -7,10 +7,10 @@
  */
 package com.eventsourcing.cep.protocols;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Model;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.cep.events.Deleted;
 import com.eventsourcing.cep.events.Undeleted;
 import lombok.Getter;
@@ -22,7 +22,8 @@ import org.testng.annotations.Test;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class DeletedProtocolTest extends RepositoryTest {
 
@@ -32,14 +33,14 @@ public class DeletedProtocolTest extends RepositoryTest {
     }
 
     @Accessors(fluent = true)
-    public static class Delete extends Command<Void> {
+    public static class Delete extends StandardCommand<Void> {
 
         @Getter @Setter
         private UUID id;
         private UUID eventId;
 
         @Override
-        public Stream<Event> events(Repository repository) throws Exception {
+        public Stream<? extends Event> events(Repository repository) throws Exception {
             Deleted reference = new Deleted().reference(id);
             eventId = reference.uuid();
             return Stream.of(reference);
@@ -52,13 +53,13 @@ public class DeletedProtocolTest extends RepositoryTest {
     }
 
     @Accessors(fluent = true)
-    public static class Undelete extends Command<Void> {
+    public static class Undelete extends StandardCommand<Void> {
 
         @Getter @Setter
         private UUID id;
 
         @Override
-        public Stream<Event> events(Repository repository) throws Exception {
+        public Stream<? extends Event> events(Repository repository) throws Exception {
             return Stream.of(new Undeleted().deleted(id));
         }
 

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DescriptionProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DescriptionProtocolTest.java
@@ -7,10 +7,10 @@
  */
 package com.eventsourcing.cep.protocols;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Model;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.cep.events.DescriptionChanged;
 import com.eventsourcing.hlc.HybridTimestamp;
 import lombok.Getter;
@@ -32,7 +32,7 @@ public class DescriptionProtocolTest extends RepositoryTest {
     }
 
     @Accessors(fluent = true)
-    public static class ChangeDescription extends Command<String> {
+    public static class ChangeDescription extends StandardCommand<String> {
 
         @Getter @Setter
         private UUID id;
@@ -40,9 +40,11 @@ public class DescriptionProtocolTest extends RepositoryTest {
         private String description;
 
         @Override
-        public Stream<Event> events(Repository repository) throws Exception {
-            return Stream.of((Event)new DescriptionChanged().reference(id).description(description).timestamp(timestamp
-                                                                                                                   ()));
+        public Stream<? extends Event> events(Repository repository) throws Exception {
+            return Stream.of((Event)new DescriptionChanged()
+                    .reference(id)
+                    .description(description)
+                    .timestamp(timestamp()));
         }
 
         @Override

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/NameProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/NameProtocolTest.java
@@ -7,10 +7,10 @@
  */
 package com.eventsourcing.cep.protocols;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Model;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.cep.events.NameChanged;
 import com.eventsourcing.hlc.HybridTimestamp;
 import lombok.Getter;
@@ -22,7 +22,8 @@ import org.testng.annotations.Test;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class NameProtocolTest extends RepositoryTest {
 
@@ -31,7 +32,7 @@ public class NameProtocolTest extends RepositoryTest {
     }
 
     @Accessors(fluent = true)
-    public static class Rename extends Command<String> {
+    public static class Rename extends StandardCommand<String> {
 
         @Getter @Setter
         private UUID id;
@@ -39,7 +40,7 @@ public class NameProtocolTest extends RepositoryTest {
         private String name;
 
         @Override
-        public Stream<Event> events(Repository repository) throws Exception {
+        public Stream<? extends Event> events(Repository repository) throws Exception {
             return Stream.of((Event) new NameChanged().reference(id).name(name).timestamp(timestamp()));
         }
 

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/RepositoryTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/RepositoryTest.java
@@ -7,13 +7,13 @@
  */
 package com.eventsourcing.cep.protocols;
 
+import com.eventsourcing.Repository;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.index.MemoryIndexEngine;
 import com.eventsourcing.repository.MemoryJournal;
 import com.eventsourcing.repository.MemoryLockProvider;
 import com.eventsourcing.repository.PackageCommandSetProvider;
 import com.eventsourcing.repository.PackageEventSetProvider;
-import com.eventsourcing.Repository;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 

--- a/eventsourcing-core/src/main/java/com/eventsourcing/Command.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/Command.java
@@ -21,20 +21,7 @@ import java.util.stream.Stream;
  *
  * @param <R> result type
  */
-public abstract class Command<R> extends Entity {
-
-    /**
-     * Returns a stream of events that should be recorded. By default, an empty stream returned.
-     *
-     * @param repository Configured repository
-     * @return stream of events
-     * @throws Exception if the command is to be rejected, an exception has to be thrown. In this case, no events will
-     *                   be recorded
-     */
-
-    public Stream<Event> events(Repository repository) throws Exception {
-        return Stream.empty();
-    }
+public interface Command<R> extends Entity<Command<R>> {
 
     /**
      * Returns a stream of events that should be recorded. By default, an empty stream returned.
@@ -53,8 +40,8 @@ public abstract class Command<R> extends Entity {
      * @throws Exception if the command is to be rejected, an exception has to be thrown. In this case, no events will
      *                   be recorded
      */
-    public Stream<Event> events(Repository repository, LockProvider lockProvider) throws Exception {
-        return events(repository);
+    default Stream<? extends Event> events(Repository repository, LockProvider lockProvider) throws Exception {
+        return Stream.empty();
     }
 
     /**
@@ -66,8 +53,7 @@ public abstract class Command<R> extends Entity {
      *
      * @return Result
      */
-    @LayoutIgnore
-    public R onCompletion() {
+    @LayoutIgnore default R onCompletion() {
         return null;
     }
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/Entity.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/Entity.java
@@ -9,44 +9,12 @@ package com.eventsourcing;
 
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.layout.LayoutIgnore;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 
 import java.util.UUID;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.LinkedBlockingDeque;
 
-public class Entity {
-
-    private static LinkedBlockingDeque<UUID> uuids = new LinkedBlockingDeque<>(10_000);
-
-    static {
-        new Thread(() -> {
-            while (true) {
-                try {
-                    uuids.put(UUID.randomUUID());
-                } catch (InterruptedException e) {
-                }
-            }
-        }).start();
-    }
-
-    @Setter @Accessors(fluent = true)
-    private UUID uuid;
-
-    @LayoutIgnore
-    public UUID uuid() {
-        while (uuid == null) {
-            try {
-                uuid = uuids.take();
-            } catch (InterruptedException e) {
-            }
-        }
-        return uuid;
-    }
-
-    @Getter @Setter @Accessors(fluent = true)
-    private HybridTimestamp timestamp;
-
+public interface Entity<E extends Entity> {
+    @LayoutIgnore UUID uuid();
+    E uuid(UUID uuid);
+    HybridTimestamp timestamp();
+    E timestamp(HybridTimestamp timestamp);
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/Repository.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/Repository.java
@@ -186,7 +186,7 @@ public interface Repository extends Service {
      * @return
      */
     default <E extends Entity> ResultSet<EntityHandle<E>> query(Class<E> klass, Query<EntityHandle<E>> query,
-                                                                QueryOptions queryOptions) {
+                                                                        QueryOptions queryOptions) {
         return getIndexEngine().getIndexedCollection(klass).retrieve(query, queryOptions);
     }
 

--- a/eventsourcing-core/src/main/java/com/eventsourcing/StandardCommand.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/StandardCommand.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing;
+
+import com.eventsourcing.repository.LockProvider;
+
+import java.util.stream.Stream;
+
+/**
+ * Thin implementation of {@link Command}
+ * @param <R> result type
+ */
+public abstract class StandardCommand<R> extends StandardEntity<Command<R>> implements Command<R> {
+
+    /**
+     * Returns a stream of events that should be recorded. By default, an empty stream returned.
+     *
+     * @param repository Configured repository
+     * @return stream of events
+     * @throws Exception if the command is to be rejected, an exception has to be thrown. In this case, no events will
+     *                   be recorded
+     */
+
+    public Stream<? extends Event> events(Repository repository) throws Exception {
+        return Stream.empty();
+    }
+
+    @Override public Stream<? extends Event> events(Repository repository, LockProvider lockProvider) throws Exception {
+        return events(repository);
+    }
+
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/StandardEntity.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/StandardEntity.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing;
+
+import com.eventsourcing.hlc.HybridTimestamp;
+import com.eventsourcing.layout.LayoutIgnore;
+import lombok.experimental.Accessors;
+
+import java.util.UUID;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.LinkedBlockingDeque;
+
+/**
+ * Standard {@link Entity} implementation. Will generate UUID if one is not provided.
+ * @param <E>
+ */
+public abstract class StandardEntity<E extends Entity> implements Entity<E> {
+
+    private static LinkedBlockingDeque<UUID> uuids = new LinkedBlockingDeque<>(10_000);
+
+    static {
+        new Thread(() -> {
+            while (true) {
+                try {
+                    uuids.put(UUID.randomUUID());
+                } catch (InterruptedException e) {
+                }
+            }
+        }).start();
+    }
+
+    private UUID uuid;
+
+    /**
+     * Returns entity UUID. Generates one if none assigned.
+     *
+     * @return Entity UUID
+     */
+    @Override @LayoutIgnore
+    public UUID uuid() {
+        while (uuid == null) {
+            try {
+                uuid = uuids.take();
+            } catch (InterruptedException e) {
+            }
+        }
+        return uuid;
+    }
+
+    private HybridTimestamp timestamp;
+
+    public HybridTimestamp timestamp() {return this.timestamp;}
+
+    public E uuid(UUID uuid) {
+        this.uuid = uuid;
+        return (E)this;
+    }
+
+    public E timestamp(HybridTimestamp timestamp) {
+        this.timestamp = timestamp;
+        return (E)this;
+    }
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/StandardEvent.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/StandardEvent.java
@@ -7,8 +7,8 @@
  */
 package com.eventsourcing;
 
-/**a
- * Event is a statement of a fact that has occurred once written to a journal.
+/**
+ * Standard {@link Event} implementation. Doesn't add any functionality.
  */
-public interface Event extends Entity<Event> {
+public abstract class StandardEvent extends StandardEntity<Event> implements Event {
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/events/CommandTerminatedExceptionally.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/events/CommandTerminatedExceptionally.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Getter;
@@ -20,7 +20,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Accessors(fluent = true)
-public class CommandTerminatedExceptionally extends Event {
+public class CommandTerminatedExceptionally extends StandardEvent {
 
     @Getter @Setter
     private UUID commandId;

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/CQIndexEngine.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/CQIndexEngine.java
@@ -9,7 +9,6 @@ package com.eventsourcing.index;
 
 import com.eventsourcing.*;
 import com.eventsourcing.repository.Journal;
-import com.eventsourcing.Repository;
 import com.googlecode.cqengine.ConcurrentIndexedCollection;
 import com.googlecode.cqengine.IndexedCollection;
 

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/CascadingIndexEngine.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/CascadingIndexEngine.java
@@ -8,8 +8,8 @@
 package com.eventsourcing.index;
 
 import com.eventsourcing.Entity;
-import com.eventsourcing.repository.Journal;
 import com.eventsourcing.Repository;
+import com.eventsourcing.repository.Journal;
 import com.google.common.base.Joiner;
 import com.googlecode.cqengine.index.Index;
 import lombok.extern.slf4j.Slf4j;

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/EntityQueryFactory.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/EntityQueryFactory.java
@@ -7,8 +7,8 @@
  */
 package com.eventsourcing.index;
 
-import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
+import com.eventsourcing.StandardEntity;
 import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.query.Query;
 import com.googlecode.cqengine.query.option.QueryOptions;
@@ -18,7 +18,7 @@ import java.util.Collections;
 
 public class EntityQueryFactory {
 
-    public static class All<O extends Entity> extends SimpleQuery<EntityHandle<O>, O> {
+    public static class All<O extends StandardEntity> extends SimpleQuery<EntityHandle<O>, O> {
 
         final Class<O> attributeType;
 
@@ -89,7 +89,7 @@ public class EntityQueryFactory {
      * @param <O> The type of the objects in the collection
      * @return A query which matches all objects in the collection
      */
-    public static <O extends Entity> Query<EntityHandle<O>> all(Class<O> objectType) {
+    public static <O extends StandardEntity> Query<EntityHandle<O>> all(Class<O> objectType) {
         return new All<>(objectType);
     }
 

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/IndexEngine.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/IndexEngine.java
@@ -9,8 +9,8 @@ package com.eventsourcing.index;
 
 import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
-import com.eventsourcing.repository.Journal;
 import com.eventsourcing.Repository;
+import com.eventsourcing.repository.Journal;
 import com.google.common.base.Joiner;
 import com.google.common.util.concurrent.Service;
 import com.googlecode.concurrenttrees.common.Iterables;
@@ -52,7 +52,7 @@ public interface IndexEngine extends Service {
     void setRepository(Repository repository) throws IllegalStateException;
 
     @SuppressWarnings("unchecked") <O extends Entity, A> Index<O> getIndexOnAttributes(Attribute<O, A>[] attributes,
-                                                                                       IndexFeature... features)
+                                                                                               IndexFeature... features)
             throws IndexNotSupported;
 
     enum IndexFeature {

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/Indexing.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/Indexing.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.index;
 
-import com.eventsourcing.Entity;
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.annotations.Index;
 import lombok.SneakyThrows;
 import org.javatuples.Pair;
@@ -31,7 +31,7 @@ public class Indexing {
      */
     @SuppressWarnings("unchecked")
     @SneakyThrows
-    public static <O extends Entity, A> Attribute<O, A> getAttribute(Class<?> klass, String name) {
+    public static <O extends StandardEntity, A> Attribute<O, A> getAttribute(Class<?> klass, String name) {
         Stream<Pair<Index, Attribute>> stream = StreamSupport
                 .stream(Spliterators.spliteratorUnknownSize(IndexEngine.getIndexableGetters(klass).iterator(),
                                                             Spliterator.IMMUTABLE), false);

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/MemoryIndexEngine.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/MemoryIndexEngine.java
@@ -7,8 +7,8 @@
  */
 package com.eventsourcing.index;
 
-import com.eventsourcing.repository.Journal;
 import com.eventsourcing.Repository;
+import com.eventsourcing.repository.Journal;
 import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.index.compound.CompoundIndex;
 import com.googlecode.cqengine.index.hash.HashIndex;

--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/BundleCommandSetProvider.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/BundleCommandSetProvider.java
@@ -8,6 +8,7 @@
 package com.eventsourcing.repository;
 
 import com.eventsourcing.Command;
+import com.eventsourcing.StandardCommand;
 
 import java.util.HashSet;
 import java.util.List;
@@ -18,10 +19,10 @@ import java.util.Set;
  */
 public class BundleCommandSetProvider implements BundleClassScanner, CommandSetProvider {
 
-    private final List<Class<? extends Command>> klasses;
+    private final List<Class<? extends StandardCommand>> klasses;
 
     public BundleCommandSetProvider(Class<?> classInABundle) {
-        klasses = findSubTypesOf(classInABundle, Command.class);
+        klasses = findSubTypesOf(classInABundle, StandardCommand.class);
     }
 
     @Override

--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/DisruptorCommandConsumer.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/DisruptorCommandConsumer.java
@@ -233,8 +233,8 @@ class DisruptorCommandConsumer extends AbstractService implements CommandConsume
     }
 
     private <T, C extends Command<T>> void translate(CommandEvent event, long sequence, C command,
-                                                     Collection<EntitySubscriber> subscribers,
-                                                     CompletableFuture<T> completed) {
+                                                             Collection<EntitySubscriber> subscribers,
+                                                             CompletableFuture<T> completed) {
         event.setEntitySubscribers(subscribers);
         event.setCommandClass((Class<Command>) command.getClass());
         event.commands.put(command.getClass(), command);

--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/MemoryJournal.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/MemoryJournal.java
@@ -68,13 +68,13 @@ public class MemoryJournal extends AbstractService implements Journal {
         Set<Event> eventCommands_ = new HashSet<>();
         EventConsumer eventConsumer = new EventConsumer(events_, command, listener);
 
-        Stream<Event> events;
+        Stream<? extends Event> events;
         Exception exception = null;
 
         try {
             events = command.events(repository, lockProvider);
         } catch (Exception e) {
-            events = Stream.of(new CommandTerminatedExceptionally(command.uuid(), e));
+            events = Stream.of((Event) new CommandTerminatedExceptionally(command.uuid(), e));
             exception = e;
         }
 
@@ -89,7 +89,8 @@ public class MemoryJournal extends AbstractService implements Journal {
             listener.onAbort(e);
             exception = e;
             try {
-                count = Stream.of(new CommandTerminatedExceptionally(command.uuid(), e)).peek(eventConsumer).count();
+                count = Stream.of((Event)new CommandTerminatedExceptionally(command.uuid(), e)).peek(eventConsumer)
+                              .count();
             } catch (Exception e1) {
                 events_.clear();
                 exception = e1;

--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/PackageCommandSetProvider.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/PackageCommandSetProvider.java
@@ -8,43 +8,24 @@
 package com.eventsourcing.repository;
 
 import com.eventsourcing.Command;
-import com.eventsourcing.Entity;
-import org.reflections.Configuration;
-import org.reflections.Reflections;
-import org.reflections.util.ConfigurationBuilder;
 
-import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Provides a command set from a given list of packages
  */
-public class PackageCommandSetProvider implements CommandSetProvider {
-
-    private final String[] packages;
-    private final ClassLoader[] classLoaders;
+public class PackageCommandSetProvider extends PackageScanner implements CommandSetProvider {
 
     public PackageCommandSetProvider(Package[] packages) {
-        this(packages, new ClassLoader[]{});
+        super(packages);
     }
 
     public PackageCommandSetProvider(Package[] packages, ClassLoader[] classLoaders) {
-        this.packages = Arrays.asList(packages).stream().map(Package::getName).toArray(String[]::new);
-        this.classLoaders = classLoaders;
+        super(packages, classLoaders);
     }
 
     @Override
     public Set<Class<? extends Command>> getCommands() {
-        Configuration configuration = ConfigurationBuilder.build((Object[]) packages).addClassLoaders(classLoaders);
-        Reflections reflections = new Reflections(configuration);
-        Predicate<Class<? extends Entity>> classPredicate = klass ->
-                Modifier.isPublic(klass.getModifiers()) &&
-                        (!klass.isMemberClass() || (klass.isMemberClass() && Modifier
-                                .isStatic(klass.getModifiers()))) &&
-                        !Modifier.isAbstract(klass.getModifiers());
-        return reflections.getSubTypesOf(Command.class).stream().filter(classPredicate).collect(Collectors.toSet());
+       return scan(Command.class);
     }
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/PackageEventSetProvider.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/PackageEventSetProvider.java
@@ -7,45 +7,26 @@
  */
 package com.eventsourcing.repository;
 
-import com.eventsourcing.Entity;
 import com.eventsourcing.Event;
-import org.reflections.Configuration;
-import org.reflections.Reflections;
-import org.reflections.util.ConfigurationBuilder;
 
-import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Provides an event set from a given list of packages
  */
-public class PackageEventSetProvider implements EventSetProvider {
+public class PackageEventSetProvider extends PackageScanner<Event> implements EventSetProvider {
 
-
-    private final String[] packages;
-    private final ClassLoader[] classLoaders;
 
     public PackageEventSetProvider(Package[] packages) {
-        this(packages, new ClassLoader[]{});
+        super(packages);
     }
 
     public PackageEventSetProvider(Package[] packages, ClassLoader[] classLoaders) {
-        this.packages = Arrays.asList(packages).stream().map(Package::getName).toArray(String[]::new);
-        this.classLoaders = classLoaders;
+        super(packages, classLoaders);
     }
 
     @Override
     public Set<Class<? extends Event>> getEvents() {
-        Configuration configuration = ConfigurationBuilder.build((Object[]) packages).addClassLoaders(classLoaders);
-        Reflections reflections = new Reflections(configuration);
-        Predicate<Class<? extends Entity>> classPredicate = klass ->
-                Modifier.isPublic(klass.getModifiers()) &&
-                        (!klass.isMemberClass() || (klass.isMemberClass() && Modifier
-                                .isStatic(klass.getModifiers()))) &&
-                        !Modifier.isAbstract(klass.getModifiers());
-        return reflections.getSubTypesOf(Event.class).stream().filter(classPredicate).collect(Collectors.toSet());
+       return scan(Event.class);
     }
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/PackageScanner.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/PackageScanner.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.repository;
+
+import com.google.common.collect.Sets;
+import org.reflections.Configuration;
+import org.reflections.ReflectionUtils;
+import org.reflections.Reflections;
+import org.reflections.scanners.AbstractScanner;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+abstract class PackageScanner<T> {
+
+    private final String[] packages;
+    private final ClassLoader[] classLoaders;
+
+    public PackageScanner(Package[] packages) {
+        this(packages, new ClassLoader[]{});
+    }
+
+    public PackageScanner(Package[] packages, ClassLoader[] classLoaders) {
+        this.packages = Arrays.asList(packages).stream().map(Package::getName).toArray(String[]::new);
+        this.classLoaders = classLoaders;
+    }
+    Set<Class<? extends T>> scan(Class<? extends T> aClass) {
+        Configuration configuration = ConfigurationBuilder.build((Object[]) packages).addClassLoaders(classLoaders)
+                                                          .addScanners(new AssignableScanner(aClass));
+        Reflections reflections = new Reflections(configuration);
+        Predicate<Class<? extends T>> classPredicate = klass ->
+                Modifier.isPublic(klass.getModifiers()) &&
+                        (!klass.isMemberClass() || (klass.isMemberClass() && Modifier
+                                .isStatic(klass.getModifiers()))) &&
+                        !Modifier.isInterface(klass.getModifiers()) &&
+                        !Modifier.isAbstract(klass.getModifiers());
+        HashSet<Class<? extends T>> subtypes = Sets.newHashSet(
+                ReflectionUtils.forNames(
+                        reflections.getStore()
+                                   .getAll(AssignableScanner.class.getSimpleName(),
+                                           Collections.singletonList(aClass.getName())), classLoaders));
+        return subtypes.stream().filter(classPredicate).collect(Collectors.toSet());
+    }
+
+    private static class AssignableScanner extends AbstractScanner {
+
+        private final Class klass;
+
+        AssignableScanner(Class klass) {this.klass = klass;}
+
+        @Override public void scan(Object cls) {
+            String className = getMetadataAdapter().getClassName(cls);
+            Class<?> aClass = ReflectionUtils.forName(className, getConfiguration().getClassLoaders());
+
+            if (acceptResult(klass.getName()) && klass.isAssignableFrom(aClass) && aClass != klass) {
+                getStore().put(klass.getName(), className);
+            }
+
+        }
+    }
+}

--- a/eventsourcing-core/src/test/java/boguspackage/BogusCommand.java
+++ b/eventsourcing-core/src/test/java/boguspackage/BogusCommand.java
@@ -7,16 +7,16 @@
  */
 package boguspackage;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 
 import java.util.stream.Stream;
 
-public class BogusCommand extends Command<String> {
+public class BogusCommand extends StandardCommand<String> {
 
     @Override
-    public Stream<Event> events(Repository repository) throws Exception {
+    public Stream<? extends Event> events(Repository repository) throws Exception {
         return Stream.of(new BogusEvent());
     }
 

--- a/eventsourcing-core/src/test/java/boguspackage/BogusEvent.java
+++ b/eventsourcing-core/src/test/java/boguspackage/BogusEvent.java
@@ -7,7 +7,7 @@
  */
 package boguspackage;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
@@ -19,7 +19,7 @@ import static com.eventsourcing.index.IndexEngine.IndexFeature.EQ;
 import static com.eventsourcing.index.IndexEngine.IndexFeature.SC;
 
 @Accessors(fluent = true)
-public class BogusEvent extends Event {
+public class BogusEvent extends StandardEvent {
     @Getter @Setter
     private String string = "bogus";
 

--- a/eventsourcing-core/src/test/java/com/eventsourcing/EntityTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/EntityTest.java
@@ -18,7 +18,7 @@ public class EntityTest {
 
     @Test
     public void uuidGeneration() {
-        Entity entity = new Entity();
+        Entity entity = new StandardEntity() {};
         UUID uuid = entity.uuid();
         assertNotNull(uuid);
         assertEquals(uuid, entity.uuid());

--- a/eventsourcing-core/src/test/java/com/eventsourcing/JournalTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/JournalTest.java
@@ -30,7 +30,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public abstract class JournalTest<T extends Journal> {
 
@@ -68,12 +69,12 @@ public abstract class JournalTest<T extends Journal> {
         journal.clear();
     }
 
-    public static class TestEvent extends Event {}
+    public static class TestEvent extends StandardEvent {}
 
-    public static class AnotherTestEvent extends Event {}
+    public static class AnotherTestEvent extends StandardEvent {}
 
     @EqualsAndHashCode(callSuper = false)
-    public static class TestCommand extends Command<Void> {
+    public static class TestCommand extends StandardCommand<Void> {
         @Getter @Setter
         private boolean events;
 
@@ -85,18 +86,18 @@ public abstract class JournalTest<T extends Journal> {
         }
 
         @Override
-        public Stream<Event> events(Repository repository) throws Exception {
+        public Stream<? extends Event> events(Repository repository) throws Exception {
             if (events) {
-                return Stream.of(new TestEvent());
+                return Stream.of((Event)new TestEvent());
             } else {
                 return super.events(repository);
             }
         }
     }
 
-    public static class ExceptionalTestCommand extends Command<Void> {
+    public static class ExceptionalTestCommand extends StandardCommand<Void> {
         @Override
-        public Stream<Event> events(Repository repository) throws Exception {
+        public Stream<? extends Event> events(Repository repository) throws Exception {
             return Stream.generate((Supplier<Event>) () -> {
                 throw new IllegalStateException();
             });
@@ -228,14 +229,14 @@ public abstract class JournalTest<T extends Journal> {
     }
 
     @EqualsAndHashCode(callSuper = false)
-    public static class EventsCommand extends Command<Void> {
+    public static class EventsCommand extends StandardCommand<Void> {
 
         public EventsCommand() {
         }
 
         @Override
-        public Stream<Event> events(Repository repository) throws Exception {
-            return Stream.of(new TestEvent(), new AnotherTestEvent());
+        public Stream<? extends Event> events(Repository repository) throws Exception {
+            return Stream.of((Event)new TestEvent(), (Event)new AnotherTestEvent());
         }
     }
     @Test

--- a/eventsourcing-core/src/test/java/com/eventsourcing/LockProviderTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/LockProviderTest.java
@@ -10,7 +10,10 @@ package com.eventsourcing;
 import com.eventsourcing.repository.LockProvider;
 import org.testng.annotations.Test;
 
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.testng.Assert.*;
 

--- a/eventsourcing-core/src/test/java/com/eventsourcing/PersistentJournalTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/PersistentJournalTest.java
@@ -50,7 +50,7 @@ public abstract class PersistentJournalTest<T extends Journal> extends JournalTe
         timestamp.update();
         List<Event> events = new ArrayList<>();
         TestCommand command = new TestCommand(true);
-        journal.journal((Command<?>) command.timestamp(timestamp), new Journal.Listener() {
+        journal.journal((StandardCommand<?>) command.timestamp(timestamp), new Journal.Listener() {
             @Override
             public void onEvent(Event event) {
                 events.add(event);

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/CascadingIndexEngineTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/CascadingIndexEngineTest.java
@@ -7,10 +7,10 @@
  */
 package com.eventsourcing.index;
 
-import com.eventsourcing.Entity;
+import com.eventsourcing.Repository;
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.repository.Journal;
 import com.eventsourcing.repository.MemoryJournal;
-import com.eventsourcing.Repository;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.SneakyThrows;
 import org.testng.annotations.Test;
@@ -41,7 +41,7 @@ public class CascadingIndexEngineTest {
         }
     }
 
-    private static class MyEntity extends Entity {}
+    private static class MyEntity extends StandardEntity {}
 
     private static SimpleAttribute<MyEntity, UUID> INDEX = new SimpleAttribute<MyEntity, UUID>("idx") {
         @Override

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/EntityQueryFactoryTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/EntityQueryFactoryTest.java
@@ -7,13 +7,14 @@
  */
 package com.eventsourcing.index;
 
-import com.eventsourcing.*;
+import com.eventsourcing.EntityHandle;
+import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.repository.MemoryJournal;
 import com.eventsourcing.repository.MemoryLockProvider;
 import com.eventsourcing.repository.PackageCommandSetProvider;
 import com.eventsourcing.repository.PackageEventSetProvider;
-import com.eventsourcing.Repository;
 import com.googlecode.cqengine.resultset.ResultSet;
 import lombok.SneakyThrows;
 import org.testng.annotations.AfterMethod;
@@ -47,7 +48,7 @@ public class EntityQueryFactoryTest {
         repository.stopAsync().awaitTerminated();
     }
 
-    public static class TestCommand extends Command<Void> {}
+    public static class TestCommand extends StandardCommand<Void> {}
 
     @Test @SneakyThrows
     public void all() {

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexEngineTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexEngineTest.java
@@ -8,13 +8,15 @@
 package com.eventsourcing.index;
 
 import com.eventsourcing.*;
-import com.eventsourcing.Repository;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.repository.*;
 import com.googlecode.cqengine.IndexedCollection;
 import com.googlecode.cqengine.query.option.QueryOptions;
-import lombok.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.SneakyThrows;
 import lombok.experimental.Accessors;
 import org.javatuples.Pair;
 import org.testng.annotations.AfterClass;
@@ -28,9 +30,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static com.googlecode.cqengine.query.QueryFactory.*;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public abstract class IndexEngineTest<T extends IndexEngine> {
 
@@ -75,7 +75,7 @@ public abstract class IndexEngineTest<T extends IndexEngine> {
 
 
     @EqualsAndHashCode(callSuper = false)
-    public static class TestEvent extends Event {
+    public static class TestEvent extends StandardEvent {
         @Getter @Setter
         private String string;
 
@@ -103,12 +103,12 @@ public abstract class IndexEngineTest<T extends IndexEngine> {
     }
 
     @Accessors(fluent = true)
-    public static class TestCommand extends Command<Void> {
+    public static class TestCommand extends StandardCommand<Void> {
         @Getter @Setter
         private String string;
 
         @Override
-        public Stream<Event> events(Repository repository) {
+        public Stream<? extends Event> events(Repository repository) {
             return Stream.of(new TestEvent(string));
         }
     }

--- a/eventsourcing-core/src/test/java/com/eventsourcing/models/Car.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/models/Car.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.models;
 
-import com.eventsourcing.Entity;
+import com.eventsourcing.StandardEntity;
 import com.googlecode.cqengine.attribute.MultiValueAttribute;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.UUID;
 
 @ToString
-public class Car extends Entity {
+public class Car extends StandardEntity {
     public enum Color {RED, GREEN, BLUE, BLACK, WHITE}
 
     @Getter @Setter

--- a/eventsourcing-h2/src/main/java/com/eventsourcing/h2/MVStoreIndexEngine.java
+++ b/eventsourcing-h2/src/main/java/com/eventsourcing/h2/MVStoreIndexEngine.java
@@ -7,12 +7,12 @@
  */
 package com.eventsourcing.h2;
 
-import com.eventsourcing.repository.Journal;
 import com.eventsourcing.Repository;
 import com.eventsourcing.h2.index.HashIndex;
 import com.eventsourcing.h2.index.UniqueIndex;
 import com.eventsourcing.index.CQIndexEngine;
 import com.eventsourcing.index.IndexEngine;
+import com.eventsourcing.repository.Journal;
 import com.googlecode.cqengine.attribute.Attribute;
 import org.h2.mvstore.MVStore;
 import org.osgi.service.component.ComponentContext;

--- a/eventsourcing-h2/src/test/java/com/eventsourcing/h2/ByteBufferDataTypeTest.java
+++ b/eventsourcing-h2/src/test/java/com/eventsourcing/h2/ByteBufferDataTypeTest.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 public class ByteBufferDataTypeTest {
     @Test

--- a/eventsourcing-h2/src/test/java/com/eventsourcing/h2/MVStoreJournalRepositoryTest.java
+++ b/eventsourcing-h2/src/test/java/com/eventsourcing/h2/MVStoreJournalRepositoryTest.java
@@ -7,9 +7,9 @@
  */
 package com.eventsourcing.h2;
 
+import com.eventsourcing.RepositoryTest;
 import com.eventsourcing.repository.Journal;
 import com.eventsourcing.repository.RepositoryImpl;
-import com.eventsourcing.RepositoryTest;
 import org.h2.mvstore.MVStore;
 import org.testng.annotations.Test;
 

--- a/eventsourcing-h2/src/test/java/com/eventsourcing/h2/PersistentMVStoreJournalTest.java
+++ b/eventsourcing-h2/src/test/java/com/eventsourcing/h2/PersistentMVStoreJournalTest.java
@@ -7,8 +7,8 @@
  */
 package com.eventsourcing.h2;
 
-import com.eventsourcing.Event;
 import com.eventsourcing.PersistentJournalTest;
+import com.eventsourcing.StandardEvent;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
@@ -73,7 +73,7 @@ public class PersistentMVStoreJournalTest extends PersistentJournalTest<MVStoreJ
         }
     }
 
-    public static class TestEvent extends Event {
+    public static class TestEvent extends StandardEvent {
         @Getter @Setter
         private String value;
     }

--- a/eventsourcing-hlc/src/test/java/com/eventsourcing/hlc/HybridTimestampTest.java
+++ b/eventsourcing-hlc/src/test/java/com/eventsourcing/hlc/HybridTimestampTest.java
@@ -7,7 +7,10 @@
  */
 package com.eventsourcing.hlc;
 
-import com.eventsourcing.layout.*;
+import com.eventsourcing.layout.Deserializer;
+import com.eventsourcing.layout.Layout;
+import com.eventsourcing.layout.Property;
+import com.eventsourcing.layout.Serializer;
 import com.google.common.util.concurrent.AbstractService;
 import lombok.SneakyThrows;
 import org.testng.annotations.BeforeClass;

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/Deserializer.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/Deserializer.java
@@ -7,6 +7,7 @@
  */
 package com.eventsourcing.layout;
 
+import lombok.NonNull;
 import lombok.SneakyThrows;
 
 import java.nio.ByteBuffer;
@@ -21,7 +22,7 @@ public class Deserializer<T> implements com.eventsourcing.layout.core.Deserializ
 
     private final Layout<T> layout;
 
-    public Deserializer(Layout<T> layout) throws NoEmptyConstructorException {
+    public Deserializer(@NonNull Layout<T> layout) throws NoEmptyConstructorException {
         if (layout.isReadOnly()) {
             throw new IllegalArgumentException("Read-only layout");
         }

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/Serializer.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/Serializer.java
@@ -7,6 +7,8 @@
  */
 package com.eventsourcing.layout;
 
+import lombok.NonNull;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -18,7 +20,7 @@ public class Serializer<T> implements com.eventsourcing.layout.core.Serializer<T
 
     private final Layout<T> layout;
 
-    public Serializer(Layout<T> layout) {
+    public Serializer(@NonNull Layout<T> layout) {
         this.layout = layout;
     }
 

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/TypeHandler.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/TypeHandler.java
@@ -12,7 +12,6 @@ import com.eventsourcing.layout.types.*;
 import com.fasterxml.classmate.ResolvedType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.AnnotatedType;
 import java.math.BigDecimal;

--- a/eventsourcing-layout/src/test/java/com/eventsourcing/layout/PropertyTest.java
+++ b/eventsourcing-layout/src/test/java/com/eventsourcing/layout/PropertyTest.java
@@ -10,7 +10,8 @@ package com.eventsourcing.layout;
 import lombok.SneakyThrows;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class PropertyTest {
 

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AddProductToOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AddProductToOrder.java
@@ -7,9 +7,9 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.Order;
 import com.eventsourcing.examples.order.events.ProductAddedToOrder;
 import lombok.*;
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class AddProductToOrder extends Command<Order.Item> {
+public class AddProductToOrder extends StandardCommand<Order.Item> {
 
     @Getter @Setter @NonNull
     private UUID orderId;
@@ -36,7 +36,7 @@ public class AddProductToOrder extends Command<Order.Item> {
     private ProductAddedToOrder addedToOrder;
 
     @Override
-    public Stream<Event> events(Repository repository) throws Exception {
+    public Stream<? extends Event> events(Repository repository) throws Exception {
         this.repository = repository;
         addedToOrder = new ProductAddedToOrder(orderId, productId, quantity);
         return Stream.of(addedToOrder);

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AdjustItemQuantity.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AdjustItemQuantity.java
@@ -7,9 +7,9 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.ItemQuantityAdjusted;
 import lombok.*;
 import lombok.experimental.Accessors;
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class AdjustItemQuantity extends Command<Void> {
+public class AdjustItemQuantity extends StandardCommand<Void> {
     @Getter @Setter @NonNull
     private UUID itemId;
 
@@ -28,7 +28,7 @@ public class AdjustItemQuantity extends Command<Void> {
     private Integer quantity;
 
     @Override
-    public Stream<Event> events(Repository repository) throws Exception {
+    public Stream<? extends Event> events(Repository repository) throws Exception {
         return Stream.of(new ItemQuantityAdjusted(itemId, quantity));
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CancelOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CancelOrder.java
@@ -7,9 +7,9 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.OrderCancelled;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,13 +23,13 @@ import java.util.stream.Stream;
 @AllArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class CancelOrder extends Command<Void> {
+public class CancelOrder extends StandardCommand<Void> {
 
     @Getter @Setter
     private UUID id;
 
     @Override
-    public Stream<Event> events(Repository repository) throws Exception {
+    public Stream<? extends Event> events(Repository repository) throws Exception {
         return Stream.of(new OrderCancelled(id));
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/ChangePrice.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/ChangePrice.java
@@ -7,9 +7,9 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.PriceChanged;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 @AllArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class ChangePrice extends Command<BigDecimal> {
+public class ChangePrice extends StandardCommand<BigDecimal> {
     @Getter
     @Setter
     private UUID id;
@@ -33,7 +33,7 @@ public class ChangePrice extends Command<BigDecimal> {
     private BigDecimal price;
 
     @Override
-    public Stream<Event> events(Repository repository) throws Exception {
+    public Stream<? extends Event> events(Repository repository) throws Exception {
         return Stream.of(new PriceChanged(id, price));
     }
 

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateOrder.java
@@ -7,21 +7,21 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.Order;
 import com.eventsourcing.examples.order.events.OrderCreated;
 
 import java.util.stream.Stream;
 
-public class CreateOrder extends Command<Order> {
+public class CreateOrder extends StandardCommand<Order> {
 
     private Repository repository;
     private OrderCreated orderCreated;
 
     @Override
-    public Stream<Event> events(Repository repository) throws Exception {
+    public Stream<? extends Event> events(Repository repository) throws Exception {
         this.repository = repository;
         this.orderCreated = new OrderCreated();
         return Stream.of(orderCreated);

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateProduct.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateProduct.java
@@ -7,9 +7,9 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.Product;
 import com.eventsourcing.examples.order.events.NameChanged;
 import com.eventsourcing.examples.order.events.PriceChanged;
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 @Accessors(fluent = true)
 @RequiredArgsConstructor
 @NoArgsConstructor
-public class CreateProduct extends Command<Product> {
+public class CreateProduct extends StandardCommand<Product> {
 
     @Getter @Setter @NonNull
     private String name;
@@ -35,7 +35,7 @@ public class CreateProduct extends Command<Product> {
     private ProductCreated productCreated;
 
     @Override
-    public Stream<Event> events(Repository repository) throws Exception {
+    public Stream<? extends Event> events(Repository repository) throws Exception {
         this.repository = repository;
         productCreated = new ProductCreated();
         NameChanged nameChanged = new NameChanged(productCreated.uuid(), name);

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/RemoveItemFromOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/RemoveItemFromOrder.java
@@ -7,9 +7,9 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.ItemRemovedFromOrder;
 import lombok.*;
 import lombok.experimental.Accessors;
@@ -20,13 +20,13 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class RemoveItemFromOrder extends Command<Void> {
+public class RemoveItemFromOrder extends StandardCommand<Void> {
 
     @Getter @Setter @NonNull
     private UUID itemId;
 
     @Override
-    public Stream<Event> events(Repository repository) throws Exception {
+    public Stream<? extends Event> events(Repository repository) throws Exception {
         return Stream.of(new ItemRemovedFromOrder(itemId));
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/Rename.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/Rename.java
@@ -7,9 +7,9 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.NameChanged;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 @AllArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class Rename extends Command<String> {
+public class Rename extends StandardCommand<String> {
     @Getter @Setter
     private UUID id;
 
@@ -31,7 +31,7 @@ public class Rename extends Command<String> {
     private String name;
 
     @Override
-    public Stream<Event> events(Repository repository) throws Exception {
+    public Stream<? extends Event> events(Repository repository) throws Exception {
         return Stream.of(new NameChanged(id, name));
     }
 

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/ItemQuantityAdjusted.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/ItemQuantityAdjusted.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
@@ -21,7 +21,7 @@ import static com.eventsourcing.index.IndexEngine.IndexFeature.EQ;
 @RequiredArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class ItemQuantityAdjusted extends Event {
+public class ItemQuantityAdjusted extends StandardEvent {
     @Getter @Setter @NonNull
     private UUID itemId;
 

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/ItemRemovedFromOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/ItemRemovedFromOrder.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
@@ -21,7 +21,7 @@ import static com.eventsourcing.index.IndexEngine.IndexFeature.EQ;
 @RequiredArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class ItemRemovedFromOrder extends Event {
+public class ItemRemovedFromOrder extends StandardEvent {
     @Getter @Setter @NonNull
     private UUID itemId;
 

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/NameChanged.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/NameChanged.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
@@ -25,7 +25,7 @@ import static com.eventsourcing.index.IndexEngine.IndexFeature.*;
 @Accessors(fluent = true)
 @AllArgsConstructor
 @NoArgsConstructor
-public class NameChanged extends Event {
+public class NameChanged extends StandardEvent {
     @Getter @Setter
     private UUID id;
     @Getter @Setter

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/OrderCancelled.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/OrderCancelled.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
@@ -24,7 +24,7 @@ import static com.eventsourcing.index.IndexEngine.IndexFeature.EQ;
 @AllArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class OrderCancelled extends Event {
+public class OrderCancelled extends StandardEvent {
 
     @Getter @Setter
     private UUID id;

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/OrderCreated.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/OrderCreated.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
@@ -17,7 +17,7 @@ import java.util.UUID;
 import static com.eventsourcing.index.IndexEngine.IndexFeature.EQ;
 import static com.eventsourcing.index.IndexEngine.IndexFeature.UNIQUE;
 
-public class OrderCreated extends Event {
+public class OrderCreated extends StandardEvent {
     @Index({EQ, UNIQUE})
     public static final SimpleAttribute<OrderCreated, UUID> ID = new SimpleAttribute<OrderCreated, UUID>("id") {
         public UUID getValue(OrderCreated orderCreated, QueryOptions queryOptions) {

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/PriceChanged.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/PriceChanged.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
@@ -26,7 +26,7 @@ import static com.eventsourcing.index.IndexEngine.IndexFeature.*;
 @Accessors(fluent = true)
 @AllArgsConstructor
 @NoArgsConstructor
-public class PriceChanged extends Event {
+public class PriceChanged extends StandardEvent {
     @Getter @Setter
     private UUID id;
     @Getter @Setter

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/ProductAddedToOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/ProductAddedToOrder.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
@@ -25,7 +25,7 @@ import static com.eventsourcing.index.IndexEngine.IndexFeature.*;
 @Accessors(fluent = true)
 @AllArgsConstructor
 @NoArgsConstructor
-public class ProductAddedToOrder extends Event {
+public class ProductAddedToOrder extends StandardEvent {
     @Getter
     @Setter
     private UUID orderId;

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/ProductCreated.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/ProductCreated.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.events;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
@@ -17,7 +17,7 @@ import java.util.UUID;
 import static com.eventsourcing.index.IndexEngine.IndexFeature.EQ;
 import static com.eventsourcing.index.IndexEngine.IndexFeature.UNIQUE;
 
-public class ProductCreated extends Event {
+public class ProductCreated extends StandardEvent {
 
     @Index({EQ, UNIQUE})
     public static final SimpleAttribute<ProductCreated, UUID> ID = new SimpleAttribute<ProductCreated, UUID>("id") {

--- a/examples/order/src/test/java/com/eventsourcing/examples/order/EventsourcingTest.java
+++ b/examples/order/src/test/java/com/eventsourcing/examples/order/EventsourcingTest.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order;
 
-import com.eventsourcing.*;
+import com.eventsourcing.Repository;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.index.MemoryIndexEngine;
 import com.eventsourcing.repository.MemoryJournal;

--- a/src/jmh/java/com/eventsourcing/jmh/JournalBenchmark.java
+++ b/src/jmh/java/com/eventsourcing/jmh/JournalBenchmark.java
@@ -7,7 +7,8 @@
  */
 package com.eventsourcing.jmh;
 
-import com.eventsourcing.*;
+import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.index.IndexEngine;
@@ -16,7 +17,6 @@ import com.eventsourcing.repository.Journal;
 import com.eventsourcing.repository.MemoryLockProvider;
 import com.eventsourcing.repository.PackageCommandSetProvider;
 import com.eventsourcing.repository.PackageEventSetProvider;
-import com.eventsourcing.Repository;
 import lombok.SneakyThrows;
 import org.openjdk.jmh.annotations.*;
 
@@ -72,7 +72,7 @@ public abstract class JournalBenchmark {
     @BenchmarkMode(Mode.All)
     @SneakyThrows
     public void basicPublish() throws ExecutionException, InterruptedException {
-        journal.journal((Command<?>) new TestCommand().timestamp(timestamp));
+        journal.journal((StandardCommand<?>) new TestCommand().timestamp(timestamp));
     }
 
 

--- a/src/jmh/java/com/eventsourcing/jmh/MVStoreJournalBenchmark.java
+++ b/src/jmh/java/com/eventsourcing/jmh/MVStoreJournalBenchmark.java
@@ -7,8 +7,8 @@
  */
 package com.eventsourcing.jmh;
 
-import com.eventsourcing.repository.Journal;
 import com.eventsourcing.h2.MVStoreJournal;
+import com.eventsourcing.repository.Journal;
 import org.h2.mvstore.MVStore;
 
 import java.io.File;

--- a/src/jmh/java/com/eventsourcing/jmh/MVStoreMemoryRepositoryBenchmark.java
+++ b/src/jmh/java/com/eventsourcing/jmh/MVStoreMemoryRepositoryBenchmark.java
@@ -7,10 +7,10 @@
  */
 package com.eventsourcing.jmh;
 
-import com.eventsourcing.repository.Journal;
 import com.eventsourcing.h2.MVStoreIndexEngine;
 import com.eventsourcing.h2.MVStoreJournal;
 import com.eventsourcing.index.IndexEngine;
+import com.eventsourcing.repository.Journal;
 import org.h2.mvstore.MVStore;
 
 public class MVStoreMemoryRepositoryBenchmark extends RepositoryBenchmark {

--- a/src/jmh/java/com/eventsourcing/jmh/MVStoreRepositoryBenchmark.java
+++ b/src/jmh/java/com/eventsourcing/jmh/MVStoreRepositoryBenchmark.java
@@ -7,10 +7,10 @@
  */
 package com.eventsourcing.jmh;
 
-import com.eventsourcing.repository.Journal;
 import com.eventsourcing.h2.MVStoreIndexEngine;
 import com.eventsourcing.h2.MVStoreJournal;
 import com.eventsourcing.index.IndexEngine;
+import com.eventsourcing.repository.Journal;
 import org.h2.mvstore.MVStore;
 
 import java.io.File;

--- a/src/jmh/java/com/eventsourcing/jmh/MemoryRepositoryBenchmark.java
+++ b/src/jmh/java/com/eventsourcing/jmh/MemoryRepositoryBenchmark.java
@@ -7,10 +7,10 @@
  */
 package com.eventsourcing.jmh;
 
-import com.eventsourcing.repository.Journal;
-import com.eventsourcing.repository.MemoryJournal;
 import com.eventsourcing.index.IndexEngine;
 import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.repository.Journal;
+import com.eventsourcing.repository.MemoryJournal;
 
 public class MemoryRepositoryBenchmark extends RepositoryBenchmark {
     protected IndexEngine createIndex() {

--- a/src/jmh/java/com/eventsourcing/jmh/RepositoryBenchmark.java
+++ b/src/jmh/java/com/eventsourcing/jmh/RepositoryBenchmark.java
@@ -7,13 +7,13 @@
  */
 package com.eventsourcing.jmh;
 
+import com.eventsourcing.Repository;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.index.IndexEngine;
 import com.eventsourcing.repository.Journal;
 import com.eventsourcing.repository.MemoryLockProvider;
 import com.eventsourcing.repository.PackageCommandSetProvider;
 import com.eventsourcing.repository.PackageEventSetProvider;
-import com.eventsourcing.Repository;
 import org.openjdk.jmh.annotations.*;
 
 import java.util.concurrent.ExecutionException;

--- a/src/jmh/java/com/eventsourcing/jmh/TestCommand.java
+++ b/src/jmh/java/com/eventsourcing/jmh/TestCommand.java
@@ -7,16 +7,16 @@
  */
 package com.eventsourcing.jmh;
 
-import com.eventsourcing.Command;
 import com.eventsourcing.Event;
 import com.eventsourcing.Repository;
+import com.eventsourcing.StandardCommand;
 
 import java.util.stream.Stream;
 
-public class TestCommand extends Command<String> {
+public class TestCommand extends StandardCommand<String> {
     @Override
-    public Stream<Event> events(Repository repository) {
-        return Stream.of(new TestEvent().string("test"));
+    public Stream<? extends Event> events(Repository repository) {
+        return Stream.of((Event)new TestEvent().string("test"));
     }
 
     @Override

--- a/src/jmh/java/com/eventsourcing/jmh/TestEvent.java
+++ b/src/jmh/java/com/eventsourcing/jmh/TestEvent.java
@@ -7,14 +7,14 @@
  */
 package com.eventsourcing.jmh;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 import static com.eventsourcing.index.IndexEngine.IndexFeature.EQ;
 
-public class TestEvent extends Event {
+public class TestEvent extends StandardEvent {
     private String string;
 
     @Index({EQ})

--- a/src/jmh/java/com/eventsourcing/jmh/models/Car.java
+++ b/src/jmh/java/com/eventsourcing/jmh/models/Car.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.jmh.models;
 
-import com.eventsourcing.Entity;
+import com.eventsourcing.StandardEntity;
 import com.googlecode.cqengine.attribute.MultiValueAttribute;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.UUID;
 
 @ToString
-public class Car extends Entity {
+public class Car extends StandardEntity {
     public enum Color {RED, GREEN, BLUE, BLACK, WHITE}
 
     @Getter @Setter


### PR DESCRIPTION
This makes it harder to provide alternative implementations for these entities.

Solution: extract interfaces out of these classes and rename them to StandardEntity,
StandardCommand and StandardEvent.