### PR TITLE
Problem: passing state from Command#events to Command#onCompletion is painful

### DIFF
--- a/docs/core_concepts/command.md
+++ b/docs/core_concepts/command.md
@@ -2,10 +2,10 @@
 
 Command is a request for changes in the domain. Unlike an [event](event.md), it is not a statement of fact as it might be rejected. For example, `CreateUser` command may or may not result in an `UserCreated` event being produced.
 
-Defining a command is pretty straightforward, through subclassing `Command<T>`:
+Defining a command is pretty straightforward, through subclassing `StandardCommand<T, S>`:
 
 ```java
-public class CreateUser extends StandardCommand<User> {
+public class CreateUser extends StandardCommand<User, Void> {
   @Getter @Setter
   private String email;
 }
@@ -26,7 +26,7 @@ A more important part of any command is being able to generate events. This is d
 
 ```java
 @Override
-public Stream<? extends Event> events(Repository repository) {
-  return Stream.of(new UserCreated().setEmail(email));
+public EventStream<Void> events(Repository repository) {
+  return EventStream.of(new UserCreated().setEmail(email));
 }
 ```

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DeletedProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DeletedProtocolTest.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.cep.protocols;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.EventStream;
 import com.eventsourcing.Model;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
@@ -20,7 +20,6 @@ import lombok.experimental.Accessors;
 import org.testng.annotations.Test;
 
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -33,17 +32,17 @@ public class DeletedProtocolTest extends RepositoryTest {
     }
 
     @Accessors(fluent = true)
-    public static class Delete extends StandardCommand<Void> {
+    public static class Delete extends StandardCommand<Void, Void> {
 
         @Getter @Setter
         private UUID id;
         private UUID eventId;
 
         @Override
-        public Stream<? extends Event> events(Repository repository) throws Exception {
+        public EventStream<Void> events(Repository repository) throws Exception {
             Deleted reference = new Deleted().reference(id);
             eventId = reference.uuid();
-            return Stream.of(reference);
+            return EventStream.of(reference);
         }
 
         @Override
@@ -53,14 +52,14 @@ public class DeletedProtocolTest extends RepositoryTest {
     }
 
     @Accessors(fluent = true)
-    public static class Undelete extends StandardCommand<Void> {
+    public static class Undelete extends StandardCommand<Void, Void> {
 
         @Getter @Setter
         private UUID id;
 
         @Override
-        public Stream<? extends Event> events(Repository repository) throws Exception {
-            return Stream.of(new Undeleted().deleted(id));
+        public EventStream<Void> events(Repository repository) throws Exception {
+            return EventStream.of(new Undeleted().deleted(id));
         }
 
         @Override

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DescriptionProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DescriptionProtocolTest.java
@@ -7,10 +7,7 @@
  */
 package com.eventsourcing.cep.protocols;
 
-import com.eventsourcing.Event;
-import com.eventsourcing.Model;
-import com.eventsourcing.Repository;
-import com.eventsourcing.StandardCommand;
+import com.eventsourcing.*;
 import com.eventsourcing.cep.events.DescriptionChanged;
 import com.eventsourcing.hlc.HybridTimestamp;
 import lombok.Getter;
@@ -32,7 +29,7 @@ public class DescriptionProtocolTest extends RepositoryTest {
     }
 
     @Accessors(fluent = true)
-    public static class ChangeDescription extends StandardCommand<String> {
+    public static class ChangeDescription extends StandardCommand<String, Void> {
 
         @Getter @Setter
         private UUID id;
@@ -40,8 +37,8 @@ public class DescriptionProtocolTest extends RepositoryTest {
         private String description;
 
         @Override
-        public Stream<? extends Event> events(Repository repository) throws Exception {
-            return Stream.of((Event)new DescriptionChanged()
+        public EventStream<Void> events(Repository repository) throws Exception {
+            return EventStream.of(new DescriptionChanged()
                     .reference(id)
                     .description(description)
                     .timestamp(timestamp()));

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/NameProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/NameProtocolTest.java
@@ -7,10 +7,7 @@
  */
 package com.eventsourcing.cep.protocols;
 
-import com.eventsourcing.Event;
-import com.eventsourcing.Model;
-import com.eventsourcing.Repository;
-import com.eventsourcing.StandardCommand;
+import com.eventsourcing.*;
 import com.eventsourcing.cep.events.NameChanged;
 import com.eventsourcing.hlc.HybridTimestamp;
 import lombok.Getter;
@@ -32,7 +29,7 @@ public class NameProtocolTest extends RepositoryTest {
     }
 
     @Accessors(fluent = true)
-    public static class Rename extends StandardCommand<String> {
+    public static class Rename extends StandardCommand<String, Void> {
 
         @Getter @Setter
         private UUID id;
@@ -40,8 +37,8 @@ public class NameProtocolTest extends RepositoryTest {
         private String name;
 
         @Override
-        public Stream<? extends Event> events(Repository repository) throws Exception {
-            return Stream.of((Event) new NameChanged().reference(id).name(name).timestamp(timestamp()));
+        public EventStream<Void> events(Repository repository) throws Exception {
+            return EventStream.of(new NameChanged().reference(id).name(name).timestamp(timestamp()));
         }
 
         @Override

--- a/eventsourcing-core/src/main/java/com/eventsourcing/Command.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/Command.java
@@ -10,8 +10,6 @@ package com.eventsourcing;
 import com.eventsourcing.layout.LayoutIgnore;
 import com.eventsourcing.repository.LockProvider;
 
-import java.util.stream.Stream;
-
 /**
  * Command is a request for changes in the domain. Unlike an event,
  * it is not a statement of fact as it might be rejected.
@@ -20,8 +18,9 @@ import java.util.stream.Stream;
  * OrderConfirmed event being produced.
  *
  * @param <R> result type
+ * @param <S> state type
  */
-public interface Command<R> extends Entity<Command<R>> {
+public interface Command<R,S> extends Entity<Command<R,S>> {
 
     /**
      * Returns a stream of events that should be recorded. By default, an empty stream returned.
@@ -31,7 +30,7 @@ public interface Command<R> extends Entity<Command<R>> {
      * <p>
      * <ul>
      * <li>{@link #events(Repository, LockProvider)} threw an exception</li>
-     * <li>{@link #onCompletion()} did not release any locks</li>
+     * <li>{@link #onCompletion(Object, Repository, LockProvider)} did not release any locks</li>
      * </ul>
      *
      * @param repository   Configured repository
@@ -40,8 +39,8 @@ public interface Command<R> extends Entity<Command<R>> {
      * @throws Exception if the command is to be rejected, an exception has to be thrown. In this case, no events will
      *                   be recorded
      */
-    default Stream<? extends Event> events(Repository repository, LockProvider lockProvider) throws Exception {
-        return Stream.empty();
+    default EventStream<S> events(Repository repository, LockProvider lockProvider) throws Exception {
+        return EventStream.empty();
     }
 
     /**
@@ -53,7 +52,7 @@ public interface Command<R> extends Entity<Command<R>> {
      *
      * @return Result
      */
-    @LayoutIgnore default R onCompletion() {
+    @LayoutIgnore default R onCompletion(S state, Repository repository, LockProvider lockProvider) {
         return null;
     }
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/EventStream.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/EventStream.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing;
+
+import com.eventsourcing.repository.LockProvider;
+import lombok.Getter;
+
+import java.util.stream.Stream;
+
+/**
+ * EventStream is a wrapper around <code>Event&#60;Stream&#62;</code> that holds
+ * a typed state.
+ *
+ * It is used for event generation and passing of state from {@link Command#events(Repository, LockProvider)}
+ * to {@link Command#onCompletion(Object, Repository, LockProvider)}
+ *
+ * @param <S> state type
+ */
+public class EventStream<S> {
+    @Getter
+    private Stream<? extends Event> stream;
+    @Getter
+    private S state;
+
+    EventStream(S state, Stream<? extends Event> stream) {
+        this.state = state;
+        this.stream = stream;
+    }
+
+    public static class Builder<S>  {
+
+        private final S state;
+        private final Stream.Builder<Event> builder = Stream.builder();
+
+        public Builder(S state) {
+            this.state = state;
+        }
+
+        public void accept(Event event) {
+            builder.accept(event);
+        }
+
+        public Builder<S> add(Event event) {
+            accept(event);
+            return this;
+        }
+
+        public EventStream<S> build() {
+            return new EventStream<>(state, builder.build());
+        }
+    }
+
+    /**
+     * EventStream builder
+     *
+     * @param state state
+     * @param <S> state type
+     * @return
+     */
+    public static <S> Builder<S> builder(S state) {
+        return new Builder<>(state);
+    }
+
+    /**
+     * EventStream builder with state set to <code>null</code>
+     *
+     * @param <S> state type
+     * @return
+     */
+    public static <S> Builder<S> builder() {
+        return new Builder<>(null);
+    }
+
+    /**
+     * @param <S> state type
+     * @return empty event stream with state set to <code>null</code>
+     */
+    public static <S> EventStream<S> empty() {
+        return new EventStream<>(null, Stream.empty());
+    }
+
+    /**
+     * @param state state
+     * @param <S> state type
+     * @return empty event stream with a state
+     */
+    public static <S> EventStream<S> empty(S state) {
+        return new EventStream<>(state, Stream.empty());
+    }
+
+    /**
+     * @param state state
+     * @param stream stream of events
+     * @param <S> state type
+     * @return event stream with a state and a stream
+     */
+    public static <S> EventStream<S> ofWithState(S state, Stream<? extends Event> stream) {
+        return new EventStream<>(state, stream);
+    }
+
+    /**
+     * @param stream stream of events
+     * @param <S> state type
+     * @return event stream with a state set to <code>null</code> and a stream
+     */
+    public static <S> EventStream<S> of(Stream<? extends Event> stream) {
+        return new EventStream<>(null, stream);
+    }
+
+    /**
+     * @param state state
+     * @param event event
+     * @param <S> state type
+     * @return event stream with a state and a stream of one event
+     */
+    public static <S> EventStream<S> ofWithState(S state, Event event) {
+        return new EventStream<>(state, Stream.of(event));
+    }
+
+    /**
+     * @param event event
+     * @param <S> state type
+     * @return event stream with a state set to <code>null</code> and a stream of one event
+     */
+    public static <S> EventStream<S> of(Event event) {
+        return new EventStream<>(null, Stream.of(event));
+    }
+
+    /**
+     * @param state state
+     * @param events events
+     * @param <S> state type
+     * @return event stream with a state and a stream of multiple events
+     */
+    public static <S> EventStream<S> ofWithState(S state, Event ...events) {
+        return new EventStream<>(state, Stream.of(events));
+    }
+
+    /**
+     *
+     * @param events events
+     * @param <S> state type
+     * @return event stream with a state set to <code>null</code> and a stream of multiple events
+     */
+    public static <S> EventStream<S> of(Event ...events) {
+        return new EventStream<>(null, Stream.of(events));
+    }
+
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/Repository.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/Repository.java
@@ -181,7 +181,7 @@ public interface Repository extends Service {
      * @param <C>     Result class
      * @return {@link CompletableFuture} with command's result
      */
-    <T extends Command<C>, C> CompletableFuture<C> publish(T command);
+    <T extends Command<C, ?>, C> CompletableFuture<C> publish(T command);
 
     /**
      * Shortcut method for accessing index retrieval (see {@link #query(Class, Query, QueryOptions)} with

--- a/eventsourcing-core/src/main/java/com/eventsourcing/StandardCommand.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/StandardCommand.java
@@ -7,15 +7,15 @@
  */
 package com.eventsourcing;
 
+import com.eventsourcing.layout.LayoutIgnore;
 import com.eventsourcing.repository.LockProvider;
-
-import java.util.stream.Stream;
 
 /**
  * Thin implementation of {@link Command}
  * @param <R> result type
+ * @param <S> state type
  */
-public abstract class StandardCommand<R> extends StandardEntity<Command<R>> implements Command<R> {
+public abstract class StandardCommand<R, S> extends StandardEntity<Command<R, S>> implements Command<R, S> {
 
     /**
      * Returns a stream of events that should be recorded. By default, an empty stream returned.
@@ -26,12 +26,58 @@ public abstract class StandardCommand<R> extends StandardEntity<Command<R>> impl
      *                   be recorded
      */
 
-    public Stream<? extends Event> events(Repository repository) throws Exception {
-        return Stream.empty();
+    public EventStream<S> events(Repository repository) throws Exception {
+        return EventStream.empty();
     }
 
-    @Override public Stream<? extends Event> events(Repository repository, LockProvider lockProvider) throws Exception {
+    @Override public EventStream<S> events(Repository repository, LockProvider lockProvider) throws
+                                                                                                       Exception {
         return events(repository);
     }
 
+    /**
+     * Once all events are recorded, this callback will be invoked.
+     *
+     * By default, it calls {@link #onCompletion(Object, Repository)}
+     *
+     * @param state
+     * @param repository
+     * @param lockProvider
+     * @return result
+     */
+    @Override public R onCompletion(S state, Repository repository, LockProvider lockProvider) {
+        return onCompletion(state, repository);
+    }
+
+    /**
+     * By default, calls {@link #onCompletion(Object)}
+     *
+     * @param state
+     * @param repository
+     * @return result
+     */
+    @LayoutIgnore
+    public R onCompletion(S state, Repository repository) {
+        return onCompletion(state);
+    }
+
+    /**
+     * By default, it calls {@link #onCompletion()}
+     *
+     * @param state
+     * @return result
+     */
+    @LayoutIgnore
+    public R onCompletion(S state) {
+        return onCompletion();
+    }
+
+    /**
+     * By default, does nothing (returns <code>null</code>)
+     * @return result
+     */
+    @LayoutIgnore
+    public R onCompletion() {
+        return null;
+    }
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/StandardEntity.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/StandardEntity.java
@@ -9,10 +9,8 @@ package com.eventsourcing;
 
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.layout.LayoutIgnore;
-import lombok.experimental.Accessors;
 
 import java.util.UUID;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingDeque;
 
 /**

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/AbstractAttributeIndex.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/AbstractAttributeIndex.java
@@ -9,8 +9,6 @@ package com.eventsourcing.index;
 
 import com.eventsourcing.layout.*;
 import com.eventsourcing.layout.binary.BinarySerialization;
-import com.eventsourcing.layout.binary.ObjectBinarySerializer;
-import com.eventsourcing.layout.binary.ObjectBinaryDeserializer;
 import com.eventsourcing.layout.types.ObjectTypeHandler;
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.TypeResolver;
@@ -18,10 +16,8 @@ import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.query.Query;
 import lombok.SneakyThrows;
 
-import java.beans.IntrospectionException;
 import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.AnnotatedType;
-import java.security.NoSuchAlgorithmException;
 import java.util.Set;
 
 public abstract class AbstractAttributeIndex<A, O> extends com.googlecode.cqengine.index.support.AbstractAttributeIndex<A, O> {

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/CommandJournalPersistence.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/CommandJournalPersistence.java
@@ -15,7 +15,7 @@ import com.googlecode.cqengine.index.support.CloseableIterator;
 import com.googlecode.cqengine.persistence.support.ObjectStore;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
-public class CommandJournalPersistence<T extends Command<?>> extends JournalPersistence<T> {
+public class CommandJournalPersistence<T extends Command<?, ?>> extends JournalPersistence<T> {
     public CommandJournalPersistence(Journal journal, Class<T> klass) {
         super(journal, klass);
     }
@@ -40,7 +40,7 @@ public class CommandJournalPersistence<T extends Command<?>> extends JournalPers
 
     }
 
-    static class CommandJournalObjectStore<T extends Command<?>> extends JournalObjectStore<T> {
+    static class CommandJournalObjectStore<T extends Command<?, ?>> extends JournalObjectStore<T> {
 
         public CommandJournalObjectStore(Journal journal, Class<T> klass) {
             super(journal, klass);

--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/CommandConsumer.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/CommandConsumer.java
@@ -16,10 +16,10 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 public interface CommandConsumer extends Service {
-    default <T, C extends Command<T>> CompletableFuture<T> publish(C command) {
+    default <T, C extends Command<T, ?>> CompletableFuture<T> publish(C command) {
         return publish(command, Collections.emptyList());
     }
-    <T, C extends Command<T>> CompletableFuture<T> publish(C command, Collection<EntitySubscriber> subscribers);
+    <T, C extends Command<T, ?>> CompletableFuture<T> publish(C command, Collection<EntitySubscriber> subscribers);
 
     HybridTimestamp getTimestamp();
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/Journal.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/Journal.java
@@ -43,7 +43,7 @@ public interface Journal extends Service {
      * @param command
      * @return number of events processed
      */
-    default long journal(Command<?> command) throws Exception {
+    default long journal(Command<?, ?> command) throws Exception {
         return journal(command, DEFAULT_LISTENER);
     }
 
@@ -58,7 +58,7 @@ public interface Journal extends Service {
      * @param listener
      * @return number of events processed
      */
-    default long journal(Command<?> command, Listener listener) throws Exception {
+    default long journal(Command<?, ?> command, Listener listener) throws Exception {
         return journal(command, listener, new LocalLockProvider());
     }
 
@@ -71,7 +71,7 @@ public interface Journal extends Service {
      * @param lockProvider
      * @return number of events processed
      */
-    long journal(Command<?> command, Listener listener, LockProvider lockProvider) throws Exception;
+    long journal(Command<?, ?> command, Listener listener, LockProvider lockProvider) throws Exception;
 
     /**
      * Retrieves a command or event by UUID
@@ -89,7 +89,7 @@ public interface Journal extends Service {
      * @param <T>
      * @return iterator
      */
-    <T extends Command<?>> CloseableIterator<EntityHandle<T>> commandIterator(Class<T> klass);
+    <T extends Command<?, ?>> CloseableIterator<EntityHandle<T>> commandIterator(Class<T> klass);
 
     /**
      * Iterate over events of a specific type (through {@code EntityHandler<T>})
@@ -129,6 +129,13 @@ public interface Journal extends Service {
      * Journalling listener. Useful for observing progress.
      */
     interface Listener {
+
+        /**
+         * Called when command event generation produces a state
+         * @param state
+         */
+        default void onCommandStateReceived(Object state) {}
+
         /**
          * Called when a new event is received from the stream and
          * persisted into the journal. Note that at this point the event

--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/PackageScanner.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/PackageScanner.java
@@ -15,7 +15,10 @@ import org.reflections.scanners.AbstractScanner;
 import org.reflections.util.ConfigurationBuilder;
 
 import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 

--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/RepositoryImpl.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/RepositoryImpl.java
@@ -7,7 +7,10 @@
  */
 package com.eventsourcing.repository;
 
-import com.eventsourcing.*;
+import com.eventsourcing.Command;
+import com.eventsourcing.Entity;
+import com.eventsourcing.Event;
+import com.eventsourcing.Repository;
 import com.eventsourcing.events.CommandTerminatedExceptionally;
 import com.eventsourcing.events.EventCausalityEstablished;
 import com.eventsourcing.hlc.HybridTimestamp;
@@ -218,7 +221,7 @@ public class RepositoryImpl extends AbstractService implements Repository, Repos
     }
 
     @Override
-    public <T extends Command<C>, C> CompletableFuture<C> publish(T command) {
+    public <T extends Command<C, ?>, C> CompletableFuture<C> publish(T command) {
         return this.commandConsumer.publish(command, entitySubscribers);
     }
 

--- a/eventsourcing-core/src/test/java/boguspackage/BogusCommand.java
+++ b/eventsourcing-core/src/test/java/boguspackage/BogusCommand.java
@@ -7,17 +7,15 @@
  */
 package boguspackage;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 
-import java.util.stream.Stream;
-
-public class BogusCommand extends StandardCommand<String> {
+public class BogusCommand extends StandardCommand<String, Void> {
 
     @Override
-    public Stream<? extends Event> events(Repository repository) throws Exception {
-        return Stream.of(new BogusEvent());
+    public EventStream<Void> events(Repository repository) throws Exception {
+        return EventStream.of(new BogusEvent());
     }
 
     @Override

--- a/eventsourcing-core/src/test/java/com/eventsourcing/EventStreamTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/EventStreamTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing;
+
+import com.eventsourcing.events.EventCausalityEstablished;
+import org.testng.annotations.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.testng.Assert.*;
+
+public class EventStreamTest {
+    @Test
+    public void testBuilder() throws Exception {
+        EventStream<String> test = EventStream.builder("test").add(new EventCausalityEstablished()).build();
+        assertEquals(test.getState(), "test");
+        Event event = test.getStream().findFirst().get();
+        assertTrue(event instanceof EventCausalityEstablished);
+    }
+
+    @Test
+    public void testBuilder1() throws Exception {
+        EventStream<String> test = EventStream.<String>builder().add(new EventCausalityEstablished()).build();
+        assertNull(test.getState());
+        Event event = test.getStream().findFirst().get();
+        assertTrue(event instanceof EventCausalityEstablished);
+    }
+
+    @Test
+    public void testEmpty() throws Exception {
+        EventStream<Object> empty = EventStream.empty();
+        assertNull(empty.getState());
+        assertFalse(empty.getStream().anyMatch(x -> true));
+    }
+
+    @Test
+    public void testEmpty1() throws Exception {
+        EventStream<Object> empty = EventStream.empty("empty");
+        assertEquals(empty.getState(), "empty");
+        assertFalse(empty.getStream().anyMatch(x -> true));
+    }
+
+    @Test
+    public void testOf() throws Exception {
+        EventStream<Object> test = EventStream.of(new EventCausalityEstablished());
+        assertNull(test.getState());
+        assertEquals(test.getStream().collect(Collectors.<Event>toSet()).size(), 1);
+    }
+
+    @Test
+    public void testOf1() throws Exception {
+        EventStream<String> test = EventStream.of(new EventCausalityEstablished(),
+                                                  new EventCausalityEstablished());
+        assertNull(test.getState());
+        assertEquals(test.getStream().collect(Collectors.<Event>toSet()).size(), 2);
+    }
+
+    @Test
+    public void testOf2() throws Exception {
+        EventStream<String> test = EventStream.ofWithState("test", new EventCausalityEstablished());
+        assertEquals(test.getState(), "test");
+        assertEquals(test.getStream().collect(Collectors.<Event>toSet()).size(), 1);
+    }
+
+    @Test
+    public void testOf3() throws Exception {
+        EventStream<String> test = EventStream.ofWithState("test", new EventCausalityEstablished(), new EventCausalityEstablished());
+        assertEquals(test.getState(), "test");
+        assertEquals(test.getStream().collect(Collectors.<Event>toSet()).size(), 2);
+    }
+
+    @Test
+    public void testOf4() throws Exception {
+        EventStream<String> test = EventStream.ofWithState("test", Stream.of(new EventCausalityEstablished(), new
+                EventCausalityEstablished()));
+        assertEquals(test.getState(), "test");
+        assertEquals(test.getStream().collect(Collectors.<Event>toSet()).size(), 2);
+    }
+
+    @Test
+    public void testOf5() throws Exception {
+        EventStream<String> test = EventStream.of(Stream.of(new EventCausalityEstablished(), new
+                EventCausalityEstablished()));
+        assertNull(test.getState());
+        assertEquals(test.getStream().collect(Collectors.<Event>toSet()).size(), 2);
+    }
+
+}

--- a/eventsourcing-core/src/test/java/com/eventsourcing/JournalTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/JournalTest.java
@@ -7,13 +7,11 @@
  */
 package com.eventsourcing;
 
-import com.eventsourcing.events.EventCausalityEstablished;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.index.IndexEngine;
 import com.eventsourcing.index.MemoryIndexEngine;
 import com.eventsourcing.repository.*;
-import com.googlecode.cqengine.index.support.CloseableIterator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -26,7 +24,6 @@ import org.testng.annotations.Test;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -75,7 +72,7 @@ public abstract class JournalTest<T extends Journal> {
     public static class AnotherTestEvent extends StandardEvent {}
 
     @EqualsAndHashCode(callSuper = false)
-    public static class TestCommand extends StandardCommand<Void> {
+    public static class TestCommand extends StandardCommand<Void, Void> {
         @Getter @Setter
         private boolean events;
 
@@ -87,21 +84,21 @@ public abstract class JournalTest<T extends Journal> {
         }
 
         @Override
-        public Stream<? extends Event> events(Repository repository) throws Exception {
+        public EventStream<Void> events(Repository repository) throws Exception {
             if (events) {
-                return Stream.of((Event)new TestEvent());
+                return EventStream.of(new TestEvent());
             } else {
                 return super.events(repository);
             }
         }
     }
 
-    public static class ExceptionalTestCommand extends StandardCommand<Void> {
+    public static class ExceptionalTestCommand extends StandardCommand<Void, Void> {
         @Override
-        public Stream<? extends Event> events(Repository repository) throws Exception {
-            return Stream.generate(() -> {
+        public EventStream<Void> events(Repository repository) throws Exception {
+            return EventStream.of(Stream.generate(() -> {
                 throw new IllegalStateException();
-            });
+            }));
         }
     }
 

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/AbstractAttributeIndexTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/AbstractAttributeIndexTest.java
@@ -9,7 +9,6 @@ package com.eventsourcing.index;
 
 import com.eventsourcing.EntityHandle;
 import com.eventsourcing.layout.TypeHandler;
-import com.eventsourcing.layout.types.ListTypeHandler;
 import com.eventsourcing.models.Car;
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.TypeResolver;

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/CascadingIndexEngineTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/CascadingIndexEngineTest.java
@@ -9,8 +9,8 @@ package com.eventsourcing.index;
 
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardEntity;
-import com.eventsourcing.repository.Journal;
 import com.eventsourcing.inmem.MemoryJournal;
+import com.eventsourcing.repository.Journal;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.SneakyThrows;
 import org.testng.annotations.Test;

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/EntityQueryFactoryTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/EntityQueryFactoryTest.java
@@ -48,7 +48,7 @@ public class EntityQueryFactoryTest {
         repository.stopAsync().awaitTerminated();
     }
 
-    public static class TestCommand extends StandardCommand<Void> {}
+    public static class TestCommand extends StandardCommand<Void, Void> {}
 
     @Test @SneakyThrows
     public void all() {

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexEngineTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexEngineTest.java
@@ -104,13 +104,13 @@ public abstract class IndexEngineTest<T extends IndexEngine> {
     }
 
     @Accessors(fluent = true)
-    public static class TestCommand extends StandardCommand<Void> {
+    public static class TestCommand extends StandardCommand<Void, Void> {
         @Getter @Setter
         private String string;
 
         @Override
-        public Stream<? extends Event> events(Repository repository) {
-            return Stream.of(new TestEvent(string));
+        public EventStream<Void> events(Repository repository) {
+            return EventStream.of(new TestEvent(string));
         }
     }
 

--- a/eventsourcing-migrations/src/test/java/com/eventsourcing/migrations/LayoutMigrationTest.java
+++ b/eventsourcing-migrations/src/test/java/com/eventsourcing/migrations/LayoutMigrationTest.java
@@ -34,9 +34,9 @@ public class LayoutMigrationTest extends RepositoryTest {
         super(LayoutMigrationTest.class.getPackage());
     }
 
-    public static class TestCommand extends StandardCommand<Void> {
-        @Override public Stream<? extends Event> events(Repository repository) throws Exception {
-            return Stream.of(new TestEvent1().x(0));
+    public static class TestCommand extends StandardCommand<Void, Void> {
+        @Override public EventStream<Void> events(Repository repository) throws Exception {
+            return EventStream.of(new TestEvent1().x(0));
         }
     }
 
@@ -54,13 +54,14 @@ public class LayoutMigrationTest extends RepositoryTest {
         private int y;
     }
 
-    public static class MigrationCommand extends StandardCommand<Void> {
+    public static class MigrationCommand extends StandardCommand<Void, Void> {
 
-        @Override public Stream<? extends Event> events(Repository repository, LockProvider lockProvider) throws Exception {
+        @Override public EventStream<Void> events(Repository repository, LockProvider lockProvider) throws
+                                                                                                       Exception {
             LayoutMigration<TestEvent1, TestEvent2> migration = new LayoutMigration<>(
                     TestEvent1.class, TestEvent2.class,
                     testEvent1 -> new TestEvent2().y(testEvent1.x + 1));
-            return migration.events(repository, lockProvider);
+            return EventStream.of(migration.events(repository, lockProvider));
         }
     }
 

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AdjustItemQuantity.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AdjustItemQuantity.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.ItemQuantityAdjusted;
@@ -15,12 +15,11 @@ import lombok.*;
 import lombok.experimental.Accessors;
 
 import java.util.UUID;
-import java.util.stream.Stream;
 
 @RequiredArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class AdjustItemQuantity extends StandardCommand<Void> {
+public class AdjustItemQuantity extends StandardCommand<Void, Void> {
     @Getter @Setter @NonNull
     private UUID itemId;
 
@@ -28,7 +27,7 @@ public class AdjustItemQuantity extends StandardCommand<Void> {
     private Integer quantity;
 
     @Override
-    public Stream<? extends Event> events(Repository repository) throws Exception {
-        return Stream.of(new ItemQuantityAdjusted(itemId, quantity));
+    public EventStream<Void> events(Repository repository) throws Exception {
+        return EventStream.of(new ItemQuantityAdjusted(itemId, quantity));
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CancelOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CancelOrder.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.OrderCancelled;
@@ -18,18 +18,17 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 
 import java.util.UUID;
-import java.util.stream.Stream;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class CancelOrder extends StandardCommand<Void> {
+public class CancelOrder extends StandardCommand<Void, Void> {
 
     @Getter @Setter
     private UUID id;
 
     @Override
-    public Stream<? extends Event> events(Repository repository) throws Exception {
-        return Stream.of(new OrderCancelled(id));
+    public EventStream<Void> events(Repository repository) throws Exception {
+        return EventStream.of(new OrderCancelled(id));
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/ChangePrice.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/ChangePrice.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.PriceChanged;
@@ -19,12 +19,11 @@ import lombok.experimental.Accessors;
 
 import java.math.BigDecimal;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class ChangePrice extends StandardCommand<BigDecimal> {
+public class ChangePrice extends StandardCommand<BigDecimal, Void> {
     @Getter
     @Setter
     private UUID id;
@@ -33,8 +32,8 @@ public class ChangePrice extends StandardCommand<BigDecimal> {
     private BigDecimal price;
 
     @Override
-    public Stream<? extends Event> events(Repository repository) throws Exception {
-        return Stream.of(new PriceChanged(id, price));
+    public EventStream<Void> events(Repository repository) throws Exception {
+        return EventStream.of(new PriceChanged(id, price));
     }
 
     @Override

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateOrder.java
@@ -7,28 +7,22 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.Order;
 import com.eventsourcing.examples.order.events.OrderCreated;
 
-import java.util.stream.Stream;
-
-public class CreateOrder extends StandardCommand<Order> {
-
-    private Repository repository;
-    private OrderCreated orderCreated;
+public class CreateOrder extends StandardCommand<Order, OrderCreated> {
 
     @Override
-    public Stream<? extends Event> events(Repository repository) throws Exception {
-        this.repository = repository;
-        this.orderCreated = new OrderCreated();
-        return Stream.of(orderCreated);
+    public EventStream<OrderCreated> events(Repository repository) throws Exception {
+        OrderCreated orderCreated = new OrderCreated();
+        return EventStream.ofWithState(orderCreated, orderCreated);
     }
 
     @Override
-    public Order onCompletion() {
+    public Order onCompletion(OrderCreated orderCreated, Repository repository) {
         return Order.lookup(repository, orderCreated.uuid()).get();
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/RemoveItemFromOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/RemoveItemFromOrder.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.ItemRemovedFromOrder;
@@ -15,18 +15,17 @@ import lombok.*;
 import lombok.experimental.Accessors;
 
 import java.util.UUID;
-import java.util.stream.Stream;
 
 @RequiredArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class RemoveItemFromOrder extends StandardCommand<Void> {
+public class RemoveItemFromOrder extends StandardCommand<Void, Void> {
 
     @Getter @Setter @NonNull
     private UUID itemId;
 
     @Override
-    public Stream<? extends Event> events(Repository repository) throws Exception {
-        return Stream.of(new ItemRemovedFromOrder(itemId));
+    public EventStream<Void> events(Repository repository) throws Exception {
+        return EventStream.of(new ItemRemovedFromOrder(itemId));
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/Rename.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/Rename.java
@@ -7,7 +7,7 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.NameChanged;
@@ -18,12 +18,11 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 
 import java.util.UUID;
-import java.util.stream.Stream;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Accessors(fluent = true)
-public class Rename extends StandardCommand<String> {
+public class Rename extends StandardCommand<String, Void> {
     @Getter @Setter
     private UUID id;
 
@@ -31,8 +30,8 @@ public class Rename extends StandardCommand<String> {
     private String name;
 
     @Override
-    public Stream<? extends Event> events(Repository repository) throws Exception {
-        return Stream.of(new NameChanged(id, name));
+    public EventStream<Void> events(Repository repository) throws Exception {
+        return EventStream.of(new NameChanged(id, name));
     }
 
     @Override

--- a/src/jmh/java/com/eventsourcing/jmh/JournalBenchmark.java
+++ b/src/jmh/java/com/eventsourcing/jmh/JournalBenchmark.java
@@ -72,7 +72,7 @@ public abstract class JournalBenchmark {
     @BenchmarkMode(Mode.All)
     @SneakyThrows
     public void basicPublish() throws ExecutionException, InterruptedException {
-        journal.journal((StandardCommand<?>) new TestCommand().timestamp(timestamp));
+        journal.journal(new TestCommand().timestamp(timestamp));
     }
 
 

--- a/src/jmh/java/com/eventsourcing/jmh/TestCommand.java
+++ b/src/jmh/java/com/eventsourcing/jmh/TestCommand.java
@@ -7,16 +7,14 @@
  */
 package com.eventsourcing.jmh;
 
-import com.eventsourcing.Event;
+import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 
-import java.util.stream.Stream;
-
-public class TestCommand extends StandardCommand<String> {
+public class TestCommand extends StandardCommand<String, Void> {
     @Override
-    public Stream<? extends Event> events(Repository repository) {
-        return Stream.of((Event)new TestEvent().string("test"));
+    public EventStream<Void> events(Repository repository) {
+        return EventStream.of(new TestEvent().string("test"));
     }
 
     @Override


### PR DESCRIPTION
Currently, the only way to do it is to save that state in the command
class instance, but its ugly and error prone

Solution: replace `Stream<? extend Events>` with `EventStream<S>` and extend
`Command<R>` to `Command<R,S>`