### PR TITLE
Problem: running javadoc on pre-lombok sources is error-prone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.iml
 *.ipr
 *.iws
+# Delombok
+*/src/delombok
 # Builds
 /build
 */build

--- a/build.gradle
+++ b/build.gradle
@@ -62,9 +62,18 @@ subprojects {
         }
     }
 
-    javadoc {
-        failOnError = false
+    task delombok(type: JavaExec) {
+        classpath = configurations.compile
+        main = "lombok.launch.Main"
+        args("delombok", "--quiet", "src/main/java", "--target", "src/delombok/java")
     }
+
+    javadoc {
+        source = file("src/delombok/java")
+        classpath = configurations.compile
+    }
+
+    javadoc.dependsOn(delombok)
 
     task sourceJar(type: Jar) {
         group "Build"

--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/EntitySubscriber.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/EntitySubscriber.java
@@ -18,7 +18,6 @@ import java.util.stream.Stream;
  * once they are committed. Use {@link Repository#addEntitySubscriber(EntitySubscriber)}
  * to add an entity subscriber.
  *
- * <p/>
  *
  * When an event or a command are being processed, repository will
  * use {@link EntitySubscriber#matches(Entity)} to determine whether
@@ -31,7 +30,6 @@ import java.util.stream.Stream;
  * By default, {@link EntitySubscriber#accept(Stream)} invokes {@link EntitySubscriber#onEntity(EntityHandle)}
  * for every entity handle.
  *
- * <p/>
  *
  * Most common entity subscriber is a {@link ClassEntitySubscriber}
  * @param <T>


### PR DESCRIPTION
Not only javadoc will fail to recognize some constructs Lombok code is using,
but more importantly, it will fail to see auto-generated code

Solution: delombok code before running javadoc on it