### PR TITLE
Problem: MVStoreJournal#journal goes into an infinite recursion

### DIFF
--- a/eventsourcing-h2/src/main/java/com/eventsourcing/h2/MVStoreJournal.java
+++ b/eventsourcing-h2/src/main/java/com/eventsourcing/h2/MVStoreJournal.java
@@ -284,11 +284,10 @@ public class MVStoreJournal extends AbstractService implements Journal, JournalM
             listener.onAbort(e);
 
 
-            try {
+            // if we are having an exception NOT when journalling CommandTerminatedExceptionally
+            if (events == null) {
                 journal(command, listener, lockProvider,
-                        Stream.of((Event)new CommandTerminatedExceptionally(command.uuid(), e)));
-            } catch (Exception e1) {
-                throw e1;
+                        Stream.of((Event) new CommandTerminatedExceptionally(command.uuid(), e)));
             }
 
             throw e;


### PR DESCRIPTION
When journalling CommandTerminatedExceptionally raises an exception, MVStoreJournal
goes into an inifite recursion trying to report that with another CommandTerminatedExceptionally

Solution: throw an exception if it is generated during CommandTerminatedExceptionally journalling