### PR TITLE
Problem: having to pass timestamp to all entities is a nuisance

### DIFF
--- a/docs/core_concepts/layout.md
+++ b/docs/core_concepts/layout.md
@@ -35,6 +35,13 @@ Layout defines following rules for property inclusion:
 * Property must be of a supported type (see below)
 * Property must have a matching parameter in the constructor (same parameter name or same name through `@PropertyName` parameter annotation)
 
+Additionally, inherited properties from parent classes will be admitted based on this criteria:
+
+* Every inherited property must have a getter and a setter
+* Property must be of a supported type (see below)
+* Property must have a matching parameter in any of the parent's constructors (same parameter name or same name through `@PropertyName` parameter annotation)
+
+
 Note: Since ES4J requires the use of accessors, using code generation tools like Lombok is advisable.
 
 ## Hash

--- a/eventsourcing-core/src/main/java/com/eventsourcing/StandardCommand.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/StandardCommand.java
@@ -17,6 +17,7 @@ import com.eventsourcing.repository.LockProvider;
  */
 public abstract class StandardCommand<S, R> extends StandardEntity<Command<S, R>> implements Command<S, R> {
 
+    public StandardCommand() { super(); }
     public StandardCommand(HybridTimestamp timestamp) {
         super(timestamp);
     }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/StandardEntity.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/StandardEntity.java
@@ -63,6 +63,7 @@ public abstract class StandardEntity<E extends Entity> implements Entity<E> {
         return (E)this;
     }
 
+    public StandardEntity() {}
     public StandardEntity(HybridTimestamp timestamp) {
         this.timestamp = timestamp;
     }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/StandardEvent.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/StandardEvent.java
@@ -13,6 +13,7 @@ import com.eventsourcing.hlc.HybridTimestamp;
  * Standard {@link Event} implementation. Doesn't add any functionality.
  */
 public abstract class StandardEvent extends StandardEntity<Event> implements Event {
+    public StandardEvent() { super(); }
     public StandardEvent(HybridTimestamp timestamp) {
         super(timestamp);
     }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/DisruptorCommandConsumer.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/DisruptorCommandConsumer.java
@@ -58,9 +58,7 @@ class DisruptorCommandConsumer extends AbstractService implements CommandConsume
         public CommandEvent(Iterable<Class<? extends Command>> classes) {
             for (Class<? extends Command> cmd : classes) {
                 Layout<? extends Command> layout = Layout.forClass(cmd);
-                Constructor<?> constructor = layout.getConstructor();
-                Object[] args = layout.getDefaultConstructorArguments();
-                commands.put(cmd, (Command) constructor.newInstance(args));
+                commands.put(cmd, layout.instantiate());
             }
         }
 

--- a/eventsourcing-core/src/test/java/com/eventsourcing/RepositoryTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/RepositoryTest.java
@@ -473,8 +473,7 @@ public abstract class RepositoryTest<T extends Repository> {
         };
 
         @Builder
-        public TestOptionalEvent(HybridTimestamp timestamp, Optional<String> optional) {
-            super(timestamp);
+        public TestOptionalEvent(Optional<String> optional) {
             this.optional = optional;
         }
     }

--- a/eventsourcing-core/src/test/java/com/eventsourcing/StandardCommandTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/StandardCommandTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing;
+
+import com.eventsourcing.layout.Layout;
+import lombok.SneakyThrows;
+import lombok.Value;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class StandardCommandTest {
+
+    @Value
+    public static class SomeCommand extends StandardCommand<Void, Void> {
+        String a;
+    }
+
+    @Test
+    @SneakyThrows
+    public void layout() {
+        Layout<SomeCommand> layout = Layout.forClass(SomeCommand.class);
+        assertEquals(layout.getProperties().size(), 2);
+        assertNotNull(layout.getProperty("a"));
+        assertNotNull(layout.getProperty("timestamp"));
+    }
+
+}

--- a/eventsourcing-core/src/test/java/com/eventsourcing/StandardEntityTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/StandardEntityTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing;
+
+import com.eventsourcing.layout.Layout;
+import lombok.SneakyThrows;
+import lombok.Value;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class StandardEntityTest {
+
+    @Value
+    public static class SomeEntity extends StandardEntity<SomeEntity> {
+        String a;
+    }
+
+    @Test
+    @SneakyThrows
+    public void layout() {
+        Layout<SomeEntity> layout = Layout.forClass(SomeEntity.class);
+        assertEquals(layout.getProperties().size(), 2);
+        assertNotNull(layout.getProperty("a"));
+        assertNotNull(layout.getProperty("timestamp"));
+    }
+
+}

--- a/eventsourcing-core/src/test/java/com/eventsourcing/StandardEventTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/StandardEventTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing;
+
+import com.eventsourcing.layout.Layout;
+import lombok.SneakyThrows;
+import lombok.Value;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class StandardEventTest {
+
+    @Value
+    public static class SomeEvent extends StandardEvent {
+        String a;
+    }
+
+    @Test
+    @SneakyThrows
+    public void layout() {
+        Layout<SomeEvent> layout = Layout.forClass(SomeEvent.class);
+        assertEquals(layout.getProperties().size(), 2);
+        assertNotNull(layout.getProperty("a"));
+        assertNotNull(layout.getProperty("timestamp"));
+    }
+    
+}

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/Layout.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/Layout.java
@@ -8,7 +8,8 @@
 package com.eventsourcing.layout;
 
 import com.eventsourcing.layout.binary.BinarySerialization;
-import com.fasterxml.classmate.*;
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.TypeResolver;
 import com.google.common.io.BaseEncoding;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -25,7 +26,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.function.Function;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
@@ -42,6 +42,14 @@ import java.util.stream.Stream;
  * <li>Has a matching parameter in the constructor (same parameter name or same name through {@link PropertyName}
  *     parameter annotation)</li>
  * <li>Must be of a supported type (see {@link TypeHandler#lookup(ResolvedType, AnnotatedType)})</li>
+ * </ul>
+ *
+ * Additionally, inherited properties will be qualified by the following criteria:
+ * <ul>
+ *     <li>Has both a getter and a setter (fluent or JavaBean style)</li>
+ *     <li>Has a matching parameter in the any parent's class constructor (same parameter name or same name through
+ *     {@link PropertyName} parameter annotation)</li>
+ *     <li>Must be of a supported type (see {@link TypeHandler#lookup(ResolvedType, AnnotatedType)})</li>
  * </ul>
  * <p>
  *
@@ -82,6 +90,8 @@ public class Layout<T> {
     private TypeResolver typeResolver;
     private MethodHandles.Lookup methodHandles;
 
+    private Map<String, MethodHandle> setters = new HashMap<>();
+
 
     @LayoutConstructor
     public Layout(String name, List<Property<T>> properties) {
@@ -117,8 +127,8 @@ public class Layout<T> {
         properties = new ArrayList<>();
         constructorProperties = new ArrayList<>();
 
-        constructor = findLayoutConstructor();
-        deriveProperties();
+        constructor = findLayoutConstructor(layoutClass);
+        deriveProperties(layoutClass, constructor, false);
 
         // Prepare the hash
         MessageDigest digest = MessageDigest.getInstance(DIGEST_ALGORITHM);
@@ -139,28 +149,28 @@ public class Layout<T> {
         this.hash = digest.digest();
     }
 
-    private Constructor<T> findLayoutConstructor() {
+    private <X> Constructor<X> findLayoutConstructor(Class<X> klass) {
         @SuppressWarnings("unchecked")
-        Constructor<T>[] constructors = (Constructor<T>[]) layoutClass.getConstructors();
+        Constructor<?>[] constructors = klass.getConstructors();
 
         // Must have at least one public constructor
         if (constructors.length == 0) {
-            throw new IllegalArgumentException(layoutClass + " doesn't have any public constructors");
+            throw new IllegalArgumentException(klass + " doesn't have any public constructors");
         }
 
         // Prefer wider constructors
-        List<Constructor<T>> constructorList = Arrays.asList(constructors);
+        List<Constructor<?>> constructorList = Arrays.asList(constructors);
         constructorList.sort((o1, o2) -> Integer.compare(o2.getParameterCount(), o1.getParameterCount()));
 
         // Pick the first constructor by default (if there will be only one)
-        Constructor<T> constructor = constructorList.get(0);
+        Constructor<?> constructor = constructorList.get(0);
 
         boolean ambiguityDetected = false;
 
-        for (Constructor<T> c : constructorList) {
+        for (Constructor<?> c : constructorList) {
             // If annotated as a layout constructor, pick it, end of story
             if (c.isAnnotationPresent(LayoutConstructor.class)) {
-                return c;
+                return (Constructor<X>) c;
             }
 
             // If a non-annotated constructor of the same width is found,
@@ -172,15 +182,17 @@ public class Layout<T> {
         }
 
         if (ambiguityDetected) {
-            throw new IllegalArgumentException(layoutClass + "has more than one constructor with " +
+            throw new IllegalArgumentException(klass + "has more than one constructor with " +
                                                constructor.getParameterCount() +
                                                " parameters and no @LayoutConstructor-annotated constructor");
         }
 
-        return constructor;
+        return (Constructor<X>) constructor;
     }
 
-    private void deriveProperties() throws TypeHandler.TypeHandlerException, IllegalAccessException {
+    private void deriveProperties(Class<?> klass, Constructor<T> constructor, boolean parentClass)
+            throws TypeHandler.TypeHandlerException,
+                   IllegalAccessException {
         Parameter[] parameters = constructor.getParameters();
         // Require parameter names
         for (Parameter parameter : parameters) {
@@ -192,24 +204,51 @@ public class Layout<T> {
             }
             String name = parameter.isAnnotationPresent(PropertyName.class) ?
                     parameter.getAnnotation(PropertyName.class).value() : parameter.getName();
+
+            // if there's such property already, skip processing the parameter
+            if (getNullableProperty(name) != null) {
+                continue;
+            }
+
             Optional<Method> fluent = retrieveGetter(name, parameter.getType());
             String capitalizedName = capitalizeFirstLetter(name);
             Optional<Method> getX = retrieveGetter("get" + capitalizedName, parameter.getType());
             Optional<Method> isX = (parameter.getType() == Boolean.TYPE || parameter.getType() == Boolean.class)
                     ? retrieveGetter("is" + capitalizedName, parameter.getType()) : Optional.empty();
+            Optional<Method> fluentSetter = retrieveSetter(name, parameter.getType());
+            Optional<Method> setX = retrieveSetter("set" + capitalizedName, parameter.getType());
             // prefer in this order: getX, isX, fluent
             Optional<Optional<Method>> getter = Stream.of(getX, isX, fluent).filter(Optional::isPresent).findFirst();
             if (!getter.isPresent()) {
                 throw new IllegalArgumentException("No getter found for " + layoutClass.getName() + "." + name);
             }
+            // Not a valid property if it doesn't have a setter and a setter is required
+            if (parentClass && !setX.isPresent() && !fluentSetter.isPresent()) {
+                continue;
+            }
+
+            if (parentClass) {
+                Method setterMethod = Stream.of(setX, fluentSetter).filter(Optional::isPresent).findFirst().get().get();
+                MethodHandle setterHandler = methodHandles.unreflect(setterMethod);
+                setters.put(name, setterHandler);
+            }
+
             Method method = getter.get().get();
+
             ResolvedType resolvedType = typeResolver.resolve(method.getReturnType());
             MethodHandle getterHandler = methodHandles.unreflect(method);
             Property<T> property = new Property<>(name, resolvedType,
                                                    TypeHandler.lookup(resolvedType, method.getAnnotatedReturnType()),
                                                    new GetterFunction<T>(getterHandler));
             properties.add(property);
-            constructorProperties.add(property);
+            if (!parentClass) {
+                constructorProperties.add(property);
+            }
+        }
+        Class superclass = klass.getSuperclass();
+        if (superclass != Object.class) {
+            Constructor parentConstructor = findLayoutConstructor(superclass);
+            deriveProperties(superclass, parentConstructor, true);
         }
         // Sort properties lexicographically (by default, they seem to be sorted anyway,
         // however, no such guarantee was found in the documentation upon brief inspection)
@@ -221,6 +260,19 @@ public class Layout<T> {
             Method method = layoutClass.getMethod(name);
             if (Modifier.isPublic(method.getModifiers()) &&
                     method.getReturnType() == type)  {
+                return Optional.of(method);
+            } else {
+                return Optional.empty();
+            }
+        } catch (NoSuchMethodException e) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<Method> retrieveSetter(String name, Class<?> type) {
+        try {
+            Method method = layoutClass.getMethod(name, type);
+            if (Modifier.isPublic(method.getModifiers()))  {
                 return Optional.of(method);
             } else {
                 return Optional.empty();
@@ -242,12 +294,18 @@ public class Layout<T> {
      * @throws NoSuchElementException if no such property is defined
      */
     public Property<T> getProperty(String name) throws NoSuchElementException {
+        Property<T> property = getNullableProperty(name);
+        if (property != null) return property;
+        throw new NoSuchElementException();
+    }
+
+    private Property<T> getNullableProperty(String name) {
         for (Property<T> property : properties) {
             if (property.getName().contentEquals(name)) {
                 return property;
             }
         }
-        throw new NoSuchElementException();
+        return null;
     }
 
     /**
@@ -257,7 +315,7 @@ public class Layout<T> {
      * @throws InstantiationException
      * @throws InvocationTargetException
      */
-    public T instantiate() throws IllegalAccessException, InstantiationException, InvocationTargetException {
+    public T instantiate() throws Throwable {
         return instantiate(new HashMap<>());
     }
 
@@ -270,11 +328,11 @@ public class Layout<T> {
      * @throws InstantiationException
      */
     public T instantiate(Map<Property<T>, Object> properties)
-            throws IllegalAccessException, InvocationTargetException, InstantiationException {
+            throws Throwable {
         Object[] args = new Object[constructor.getParameterCount()];
         BinarySerialization serialization = BinarySerialization.getInstance();
         for (int i = 0; i < args.length; i++) {
-            Property<T> property = this.properties.get(i);
+            Property<T> property = this.constructorProperties.get(i);
             Optional<Object> suppliedProperty = findProperty(properties, property.getName());
             if (suppliedProperty.isPresent()) {
                 args[i] = suppliedProperty.get();
@@ -286,8 +344,16 @@ public class Layout<T> {
                 args[i] = o;
             }
         }
-        int[] order = getConstructorProperties().stream().mapToInt(this.properties::indexOf).toArray();
-        return constructor.newInstance(IntStream.of(order).mapToObj(i -> args[i]).toArray());
+        T t = constructor.newInstance(args);
+        if (!setters.isEmpty()) {
+            for (Map.Entry<String, MethodHandle> entry : setters.entrySet()) {
+                Optional<Object> suppliedProperty = findProperty(properties, entry.getKey());
+                if (suppliedProperty.isPresent()) {
+                    entry.getValue().invoke(t, suppliedProperty.get());
+                }
+            }
+        }
+        return t;
     }
 
     private Optional<Object> findProperty(Map<Property<T>, Object> properties, String name) {

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/binary/ObjectBinarySerializer.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/binary/ObjectBinarySerializer.java
@@ -27,9 +27,7 @@ public class ObjectBinarySerializer<T> implements Serializer.RequiresTypeHandler
     public void serialize(ObjectTypeHandler<T> typeHandler, T value, ByteBuffer buffer) {
         Layout<T> layout = typeHandler.getLayout();
         if (value == null) {
-            Constructor<?> constructor = layout.getConstructor();
-            Object[] args = layout.getDefaultConstructorArguments();
-            serialize(typeHandler, (T) constructor.newInstance(args), buffer);
+            serialize(typeHandler, layout.instantiate(), buffer);
         } else {
             BinarySerialization serialization = BinarySerialization.getInstance();
             for (Property<T> property : layout.getProperties()) {
@@ -45,9 +43,7 @@ public class ObjectBinarySerializer<T> implements Serializer.RequiresTypeHandler
     public int size(ObjectTypeHandler<T> typeHandler, T value) {
         Layout<T> layout = typeHandler.getLayout();
         if (value == null) {
-            Constructor<?> constructor = typeHandler.getLayout().getConstructor();
-            Object[] args = layout.getDefaultConstructorArguments();
-            return size(typeHandler, (T) constructor.newInstance(args));
+            return size(typeHandler, layout.instantiate());
         }
         int sz = 0;
         BinarySerialization serialization = BinarySerialization.getInstance();

--- a/eventsourcing-layout/src/test/java/com/eventsourcing/layout/LayoutTest.java
+++ b/eventsourcing-layout/src/test/java/com/eventsourcing/layout/LayoutTest.java
@@ -326,5 +326,59 @@ public class LayoutTest {
         assertFalse(instance.isB());
     }
 
+    public static class Base0Class {
+        @Getter @Setter
+        private String a;
+        @Getter @Setter
+        private boolean b;
+
+        public Base0Class() {
+        }
+
+        public Base0Class(String a, boolean b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    public static class BaseClass extends Base0Class {
+        @Getter @Setter
+        private String a;
+        @Getter @Setter
+        private boolean b;
+
+        public BaseClass() {
+        }
+
+        public BaseClass(String a, boolean b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    @Value
+    public static class Inheritance extends BaseClass {
+        private String c;
+    }
+
+    @Test
+    @SneakyThrows
+    public void inheritance() {
+        Layout<Inheritance> layout = Layout.forClass(Inheritance.class);
+        assertEquals(layout.getProperties().size(), 3);
+        Property<Inheritance> a = layout.getProperty("a");
+        Property<Inheritance> b = layout.getProperty("b");
+        assertNotNull(a);
+        assertNotNull(b);
+        HashMap<Property<Inheritance>, Object> properties = new HashMap<>();
+        properties.put(layout.getProperty("a"), "hello");
+        properties.put(layout.getProperty("b"), true);
+        properties.put(layout.getProperty("c"), "C");
+        Inheritance instance = layout.instantiate(properties);
+        assertEquals(instance.getA(), "hello");
+        assertTrue(instance.isB());
+        assertEquals(instance.getC(), "C");
+    }
+
 
 }

--- a/eventsourcing-layout/src/test/java/com/eventsourcing/layout/LayoutTest.java
+++ b/eventsourcing-layout/src/test/java/com/eventsourcing/layout/LayoutTest.java
@@ -12,6 +12,7 @@ import org.testng.annotations.Test;
 
 import java.lang.reflect.Parameter;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
@@ -300,7 +301,7 @@ public class LayoutTest {
     }
 
     @Value
-    public static class DefaultConstructor {
+    public static class Initializer {
         private final String a;
         private boolean b;
     }
@@ -308,10 +309,22 @@ public class LayoutTest {
     @Test
     @SneakyThrows
     public void defaultConstructor() {
-        Layout<DefaultConstructor> layout = Layout.forClass(DefaultConstructor.class);
-        Object[] args = layout.getDefaultConstructorArguments();
-        DefaultConstructor instance = layout.getConstructor().newInstance(args);
+        Layout<Initializer> layout = Layout.forClass(Initializer.class);
+        Initializer instance = layout.instantiate();
         assertEquals(instance.getA(), "");
         assertFalse(instance.isB());
     }
+
+    @Test
+    @SneakyThrows
+    public void partialConstructor() {
+        Layout<Initializer> layout = Layout.forClass(Initializer.class);
+        HashMap<Property<Initializer>, Object> properties = new HashMap<>();
+        properties.put(layout.getProperty("a"), "hello");
+        Initializer instance = layout.instantiate(properties);
+        assertEquals(instance.getA(), "hello");
+        assertFalse(instance.isB());
+    }
+
+
 }

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/PostgreSQLJournal.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/PostgreSQLJournal.java
@@ -512,7 +512,7 @@ public class PostgreSQLJournal extends AbstractService implements Journal {
             } else if (typeHandler instanceof ObjectTypeHandler) {
                 Layout layout = ((ObjectTypeHandler) typeHandler).getLayout();
                 final Object o = object == null ?
-                        layout.getConstructor().newInstance(layout.getDefaultConstructorArguments()) : object;
+                        layout.instantiate() : object;
                 @SuppressWarnings("unchecked")
                 List<? extends Property> properties = layout.getProperties();
                 @SuppressWarnings("unchecked")
@@ -614,8 +614,7 @@ public class PostgreSQLJournal extends AbstractService implements Journal {
             } else
             if (typeHandler instanceof ObjectTypeHandler) {
                 Layout<?> layout = ((ObjectTypeHandler) typeHandler).getLayout();
-                Constructor<?> constructor = layout.getConstructor();
-                Object value_ = value == null ? constructor.newInstance(layout.getDefaultConstructorArguments()) : value;
+                Object value_ = value == null ? layout.instantiate() : value;
                 List<? extends Property<?>> properties = layout.getProperties();
                 int j=i;
                 for (Property p : properties) {

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AddProductToOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AddProductToOrder.java
@@ -12,7 +12,6 @@ import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.Order;
 import com.eventsourcing.examples.order.events.ProductAddedToOrder;
-import com.eventsourcing.hlc.HybridTimestamp;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -33,8 +32,7 @@ public class AddProductToOrder extends StandardCommand<ProductAddedToOrder, Orde
     private final Integer quantity;
 
     @Builder
-    public AddProductToOrder(HybridTimestamp timestamp, UUID orderId, UUID productId, Integer quantity) {
-        super(timestamp);
+    public AddProductToOrder(UUID orderId, UUID productId, Integer quantity) {
         this.orderId = orderId;
         this.productId = productId;
         this.quantity = quantity;

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AdjustItemQuantity.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AdjustItemQuantity.java
@@ -11,7 +11,6 @@ import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.ItemQuantityAdjusted;
-import com.eventsourcing.hlc.HybridTimestamp;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -28,8 +27,7 @@ public class AdjustItemQuantity extends StandardCommand<Void, Void> {
     private final Integer quantity;
 
     @Builder
-    public AdjustItemQuantity(HybridTimestamp timestamp, UUID itemId, Integer quantity) {
-        super(timestamp);
+    public AdjustItemQuantity(UUID itemId, Integer quantity) {
         this.itemId = itemId;
         this.quantity = quantity;
     }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CancelOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CancelOrder.java
@@ -11,7 +11,6 @@ import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.OrderCancelled;
-import com.eventsourcing.hlc.HybridTimestamp;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.Accessors;
@@ -25,8 +24,7 @@ public class CancelOrder extends StandardCommand<Void, Void> {
     private final UUID id;
 
     @Builder
-    public CancelOrder(HybridTimestamp timestamp, UUID id) {
-        super(timestamp);
+    public CancelOrder(UUID id) {
         this.id = id;
     }
 

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/ChangePrice.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/ChangePrice.java
@@ -11,11 +11,8 @@ import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.PriceChanged;
-import com.eventsourcing.hlc.HybridTimestamp;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
 import java.math.BigDecimal;
@@ -30,8 +27,7 @@ public class ChangePrice extends StandardCommand<Void, BigDecimal> {
     private final BigDecimal price;
 
     @Builder
-    public ChangePrice(HybridTimestamp timestamp, UUID id, BigDecimal price) {
-        super(timestamp);
+    public ChangePrice(UUID id, BigDecimal price) {
         this.id = id;
         this.price = price;
     }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateOrder.java
@@ -12,15 +12,12 @@ import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.Order;
 import com.eventsourcing.examples.order.events.OrderCreated;
-import com.eventsourcing.hlc.HybridTimestamp;
 import lombok.Builder;
 
 public class CreateOrder extends StandardCommand<OrderCreated, Order> {
 
     @Builder
-    public CreateOrder(HybridTimestamp timestamp) {
-        super(timestamp);
-    }
+    public CreateOrder() {}
 
     @Override
     public EventStream<OrderCreated> events(Repository repository) throws Exception {

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateProduct.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateProduct.java
@@ -7,7 +7,6 @@
  */
 package com.eventsourcing.examples.order.commands;
 
-import com.eventsourcing.Event;
 import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
@@ -15,7 +14,6 @@ import com.eventsourcing.examples.order.Product;
 import com.eventsourcing.examples.order.events.NameChanged;
 import com.eventsourcing.examples.order.events.PriceChanged;
 import com.eventsourcing.examples.order.events.ProductCreated;
-import com.eventsourcing.hlc.HybridTimestamp;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -33,8 +31,7 @@ public class CreateProduct extends StandardCommand<ProductCreated, Product> {
     private final BigDecimal price;
 
     @Builder
-    public CreateProduct(HybridTimestamp timestamp, String name, BigDecimal price) {
-        super(timestamp);
+    public CreateProduct(String name, BigDecimal price) {
         this.name = name;
         this.price = price;
     }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/RemoveItemFromOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/RemoveItemFromOrder.java
@@ -11,7 +11,6 @@ import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.ItemRemovedFromOrder;
-import com.eventsourcing.hlc.HybridTimestamp;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -26,8 +25,7 @@ public class RemoveItemFromOrder extends StandardCommand<Void, Void> {
     private final UUID itemId;
 
     @Builder
-    public RemoveItemFromOrder(HybridTimestamp timestamp, UUID itemId) {
-        super(timestamp);
+    public RemoveItemFromOrder(UUID itemId) {
         this.itemId = itemId;
     }
 

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/Rename.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/Rename.java
@@ -11,7 +11,6 @@ import com.eventsourcing.EventStream;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardCommand;
 import com.eventsourcing.examples.order.events.NameChanged;
-import com.eventsourcing.hlc.HybridTimestamp;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.Accessors;
@@ -27,8 +26,7 @@ public class Rename extends StandardCommand<Void, String> {
     private final String name;
 
     @Builder
-    public Rename(HybridTimestamp timestamp, UUID id, String name) {
-        super(timestamp);
+    public Rename(UUID id, String name) {
         this.id = id;
         this.name = name;
     }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/ItemQuantityAdjusted.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/ItemQuantityAdjusted.java
@@ -9,10 +9,11 @@ package com.eventsourcing.examples.order.events;
 
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
-import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
 import lombok.experimental.Accessors;
 
 import java.util.UUID;
@@ -36,8 +37,7 @@ public class ItemQuantityAdjusted extends StandardEvent {
     };
 
     @Builder
-    public ItemQuantityAdjusted(HybridTimestamp timestamp, UUID itemId, Integer quantity) {
-        super(timestamp);
+    public ItemQuantityAdjusted(UUID itemId, Integer quantity) {
         this.itemId = itemId;
         this.quantity = quantity;
     }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/ItemRemovedFromOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/ItemRemovedFromOrder.java
@@ -9,10 +9,11 @@ package com.eventsourcing.examples.order.events;
 
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
-import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
 import lombok.experimental.Accessors;
 
 import java.util.UUID;
@@ -33,8 +34,7 @@ public class ItemRemovedFromOrder extends StandardEvent {
     };
 
     @Builder
-    public ItemRemovedFromOrder(HybridTimestamp timestamp, UUID itemId) {
-        super(timestamp);
+    public ItemRemovedFromOrder(UUID itemId) {
         this.itemId = itemId;
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/NameChanged.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/NameChanged.java
@@ -44,8 +44,7 @@ public class NameChanged extends StandardEvent {
     };
 
     @Builder
-    public NameChanged(HybridTimestamp timestamp, UUID id, String name) {
-        super(timestamp);
+    public NameChanged(UUID id, String name) {
         this.id = id;
         this.name = name;
     }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/OrderCancelled.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/OrderCancelled.java
@@ -9,7 +9,6 @@ package com.eventsourcing.examples.order.events;
 
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
-import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Builder;
@@ -35,8 +34,7 @@ public class OrderCancelled extends StandardEvent {
     };
 
     @Builder
-    public OrderCancelled(HybridTimestamp timestamp, UUID id) {
-        super(timestamp);
+    public OrderCancelled(UUID id) {
         this.id = id;
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/OrderCreated.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/OrderCreated.java
@@ -9,7 +9,6 @@ package com.eventsourcing.examples.order.events;
 
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
-import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Builder;
@@ -29,7 +28,7 @@ public class OrderCreated extends StandardEvent {
 
 
     @Builder
-    public OrderCreated(HybridTimestamp timestamp) {
-        super(timestamp);
+    public OrderCreated() {
+
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/PriceChanged.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/PriceChanged.java
@@ -45,8 +45,7 @@ public class PriceChanged extends StandardEvent {
     };
 
     @Builder
-    public PriceChanged(HybridTimestamp timestamp, UUID id, BigDecimal price) {
-        super(timestamp);
+    public PriceChanged(UUID id, BigDecimal price) {
         this.id = id;
         this.price = price;
     }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/ProductAddedToOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/ProductAddedToOrder.java
@@ -14,7 +14,6 @@ import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.experimental.Accessors;
 
 import java.util.UUID;
@@ -65,8 +64,7 @@ public class ProductAddedToOrder extends StandardEvent {
     };
 
     @Builder
-    public ProductAddedToOrder(HybridTimestamp timestamp, UUID orderId, UUID productId, int quantity) {
-        super(timestamp);
+    public ProductAddedToOrder(UUID orderId, UUID productId, int quantity) {
         this.orderId = orderId;
         this.productId = productId;
         this.quantity = quantity;

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/events/ProductCreated.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/events/ProductCreated.java
@@ -9,7 +9,6 @@ package com.eventsourcing.examples.order.events;
 
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
-import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Builder;
@@ -29,7 +28,7 @@ public class ProductCreated extends StandardEvent {
     };
 
     @Builder
-    public ProductCreated(HybridTimestamp timestamp) {
-        super(timestamp);
+    public ProductCreated() {
+
     }
 }


### PR DESCRIPTION
Having to create a matching construtor for any kind of entity is
good when explicitness is sought. However, it's definitely adding
some verbosity:

```java
  @Builder
  public MyEvent(HybridTimestamp timestamp, String value) {
    super(timestamp);
     this.value = value
  }
 ```

Solution: make layout detect inherited properties

These properties MUST also have setters in order to be successfully
initialized upon instantiation.

Now the inherited properties can be omitted (but if explicitness is
required, they can be declared in the constructor explictly as well)

This merge also adds `Layout#instantiate()` method.