### PR TITLE
Problem: Kotlin doesn't produce parameter names readable by Java 8

### DIFF
--- a/eventsourcing-kotlin/build.gradle
+++ b/eventsourcing-kotlin/build.gradle
@@ -1,0 +1,32 @@
+buildscript {
+    ext.kotlin_version = '1.0.3'
+
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+apply plugin: "kotlin"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile project(':eventsourcing-layout')
+    compile project(':eventsourcing-core')
+
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+
+    testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+}
+
+license {
+    mapping 'kt', 'JAVADOC_STYLE'
+}

--- a/eventsourcing-kotlin/src/main/kotlin/Layout.kt
+++ b/eventsourcing-kotlin/src/main/kotlin/Layout.kt
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.eventsourcing.kotlin
+
+import com.eventsourcing.layout.ClassAnalyzer
+import com.eventsourcing.layout.LayoutConstructor
+import java.lang.reflect.Constructor
+import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
+import kotlin.reflect.jvm.javaConstructor
+import kotlin.reflect.jvm.javaType
+
+class KotlinParameter(val parameter : KParameter) : ClassAnalyzer.Parameter {
+    override fun getName(): String {
+        return parameter.name!!
+    }
+
+    override fun getType(): Class<*> {
+        return parameter.type.javaType as Class<*>
+    }
+
+}
+class KotlinConstructor(val constructor: KFunction<*>) : ClassAnalyzer.Constructor {
+
+    override fun isLayoutConstructor(): Boolean {
+        return constructor.annotations.find { it.javaClass.equals(LayoutConstructor::class.java) } != null
+    }
+
+    override fun getParameters(): Array<out ClassAnalyzer.Parameter> {
+        return constructor.parameters.map { KotlinParameter(it) }.toTypedArray()
+    }
+
+    override fun <X : Any?> getConstructor(): Constructor<X> {
+        return constructor.javaConstructor!! as Constructor<X>
+    }
+
+}
+class KotlinClassAnalyzer : ClassAnalyzer {
+
+    override fun getConstructors(klass: Class<*>?): Array<out ClassAnalyzer.Constructor> {
+        return klass!!.kotlin.constructors.map { KotlinConstructor(it) }.toTypedArray()
+    }
+
+}

--- a/eventsourcing-kotlin/src/test/kotlin/LayoutTest.kt
+++ b/eventsourcing-kotlin/src/test/kotlin/LayoutTest.kt
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.kotlin
+
+import com.eventsourcing.layout.Layout
+import com.eventsourcing.layout.UseClassAnalyzer
+import org.testng.annotations.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@UseClassAnalyzer(KotlinClassAnalyzer::class)
+class TestClass(val x: String)
+
+class LayoutTest {
+  @Test fun kotlinAnalyzer() {
+      val layout = Layout.forClass(TestClass::class.java)
+      assertEquals(layout.properties.size, 1)
+      val p = layout.getProperty("x")
+      assertNotNull(p)
+      assertEquals(p.get(TestClass("a")), "a")
+  }
+}

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/ClassAnalyzer.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/ClassAnalyzer.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.layout;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+
+public interface ClassAnalyzer {
+    interface Parameter {
+        String getName();
+        Class<?> getType();
+    }
+    interface Constructor {
+        boolean isLayoutConstructor();
+        Parameter[] getParameters();
+        <X> java.lang.reflect.Constructor<X> getConstructor();
+    }
+    Constructor[] getConstructors(Class<?> klass);
+}

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/JavaClassAnalyzer.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/JavaClassAnalyzer.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.layout;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+class JavaClassAnalyzer implements ClassAnalyzer {
+
+    static class JavaParameter implements Parameter {
+
+        private final java.lang.reflect.Parameter parameter;
+
+        JavaParameter(java.lang.reflect.Parameter parameter) {
+            this.parameter = parameter;
+        }
+
+        @Override public String getName() {
+            String name = parameter.getName();
+            if (!parameter.isNamePresent() &&
+                !parameter.isAnnotationPresent(PropertyName.class)) {
+                throw new IllegalArgumentException(name + " parameter name detected. " +
+                                                           "You must run javac with  -parameters argument or " +
+                                                           "use @PropertyName annotation");
+            }
+            return parameter.isAnnotationPresent(PropertyName.class) ? parameter.getAnnotation(PropertyName.class)
+                                                                                .value() : name;
+        }
+
+        @Override public Class<?> getType() {
+            return parameter.getType();
+        }
+
+    }
+    static class JavaClassConstructor implements Constructor {
+
+        @Getter
+        private java.lang.reflect.Constructor constructor;
+
+        public JavaClassConstructor(java.lang.reflect.Constructor constructor) {
+            this.constructor = constructor;
+        }
+
+        @Override public boolean isLayoutConstructor() {
+            return constructor.isAnnotationPresent(LayoutConstructor.class);
+        }
+
+        @Override public Parameter[] getParameters() {
+            Parameter[] p = new Parameter[]{};
+            return Arrays.asList(constructor.getParameters()).stream()
+                         .map(JavaParameter::new).collect(Collectors.toList()).toArray(p);
+        }
+    }
+    @Override public Constructor[] getConstructors(Class<?> klass) {
+        Constructor[] c = new Constructor[]{};
+        return Arrays.asList(klass.getConstructors()).stream()
+                     .map(JavaClassConstructor::new).collect(Collectors.toList()).toArray(c);
+
+    }
+}

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/UseClassAnalyzer.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/UseClassAnalyzer.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.layout;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UseClassAnalyzer {
+    Class<? extends ClassAnalyzer> value();
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,8 @@ include 'eventsourcing-layout'
 include 'eventsourcing-hlc'
 include 'eventsourcing-core'
 
+include 'eventsourcing-kotlin'
+
 include 'eventsourcing-inmem'
 include 'eventsourcing-h2'
 include 'eventsourcing-postgresql'


### PR DESCRIPTION
See http://stackoverflow.com/questions/30425846/how-to-get-parameter-names-via-reflection-in-kotlin

This forces Kotlin users to use @PropertyName for every parameter, which
is a suboptimal user experience.

Solution: Add @UseClassAnalyzer annotation that allows to specify
a custom class analyzer that will return propert parameter names.

This solution also implements KotlinClassAnalyzer.