### PR TITLE
Problem: OSGi StandardRepository#activate() doesn't wait until started

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/repository/RepositoryImpl.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/repository/RepositoryImpl.java
@@ -57,7 +57,7 @@ public class RepositoryImpl extends AbstractService implements Repository, Repos
     @Activate
     protected void activate(ComponentContext ctx) {
         if (!isRunning()) {
-            startAsync();
+            startAsync().awaitRunning();
         }
     }
 


### PR DESCRIPTION
This causes other services that depend on a fully running repository to fail

Solution: wait until the repository has been properly started