### PR TITLE
Problem: Gradle re-runs delombok and javadocs when nothing has changed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,12 +67,15 @@ subprojects {
     }
 
     task delombok(type: JavaExec) {
+        inputs.files(file('src/main/java'))
+        outputs.dir(file('src/main/delombok'))
         classpath = configurations.compile
         main = "lombok.launch.Main"
         args("delombok", "--quiet", "src/main/java", "--target", "src/delombok/java")
     }
 
     javadoc {
+        inputs.files(file("src/delombok/java"))
         source = file("src/delombok/java")
         classpath = configurations.compile
     }


### PR DESCRIPTION
This increases the length of repeated builds significantly

Solution: Set inputs and outputs to relevant tasks to prevent the re-runs