### PR TITLE
Problem: postgresql storage tables are hard to migrate to new versions

### DIFF
--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/PostgreSQLSerialization.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/PostgreSQLSerialization.java
@@ -65,7 +65,7 @@ public class PostgreSQLSerialization {
             Layout<?> layout = ((ObjectTypeHandler) typeHandler).getLayout();
             byte[] fingerprint = layout.getHash();
             String encoded = BaseEncoding.base16().encode(fingerprint);
-            String typname = "layout_" + encoded;
+            String typname = "layout_v1_" + encoded;
 
             PreparedStatement check = connection
                     .prepareStatement("SELECT * FROM pg_catalog.pg_type WHERE lower(typname) = lower(?)");

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/EqualityIndex.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/EqualityIndex.java
@@ -88,7 +88,7 @@ public class EqualityIndex<A, O extends Entity> extends AbstractAttributeIndex<A
             digest.update(layout.getHash());
             digest.update(attribute.getAttributeName().getBytes());
             String encodedHash = BaseEncoding.base16().encode(digest.digest());
-            tableName = "index_" + encodedHash + "_eq";
+            tableName = "index_v1_" + encodedHash + "_eq";
             if (unique) {
                 tableName += "_unique";
             }


### PR DESCRIPTION
Should the way postgresql storage organizes tables change, it'll be
a little bit of nuisance to figure out if the upgrade is necessary.

Solution: include "adapter schema" version in the identifiers of
tables and types