### PR TITLE
Problem: byte[] equality does not work in MemoryIndexEngine

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/AbstractAttributeIndex.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/AbstractAttributeIndex.java
@@ -30,6 +30,7 @@ public abstract class AbstractAttributeIndex<A, O extends Entity>
     protected ObjectDeserializer<O> objectDeserializer;
 
     private final static Serialization serialization = BinarySerialization.getInstance();
+    protected final TypeHandler attrTypeHandler;
 
     /**
      * Protected constructor, called by subclasses.
@@ -47,7 +48,7 @@ public abstract class AbstractAttributeIndex<A, O extends Entity>
         AnnotatedParameterizedType cls = (AnnotatedParameterizedType) attribute.getClass().getAnnotatedSuperclass();
         AnnotatedType annotatedType = cls.getAnnotatedActualTypeArguments()[1];
 
-        TypeHandler attrTypeHandler = TypeHandler.lookup(attributeType, annotatedType);
+        attrTypeHandler = TypeHandler.lookup(attributeType, annotatedType);
         attributeSerializer = serialization.getSerializer(attrTypeHandler);
         attributeDeserializer = serialization.getDeserializer(attrTypeHandler);
 

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/CQIndexEngine.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/CQIndexEngine.java
@@ -13,6 +13,7 @@ import com.eventsourcing.Command;
 import com.eventsourcing.Repository;
 import com.googlecode.cqengine.ConcurrentIndexedCollection;
 import com.googlecode.cqengine.IndexedCollection;
+import com.googlecode.cqengine.persistence.Persistence;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,12 +43,17 @@ public abstract class CQIndexEngine extends AbstractIndexEngine {
                 throw new IllegalArgumentException();
             }
 
-            IndexedCollection<EntityHandle<T>> indexedCollection = new ConcurrentIndexedCollection<>(tJournalPersistence);
+            IndexedCollection<EntityHandle<T>> indexedCollection = createIndexedCollection(tJournalPersistence);
             indexedCollections.put(klass.getName(), indexedCollection);
             return indexedCollection;
         } else {
             return existingCollection;
         }
+    }
+
+    protected <T extends Entity> IndexedCollection<EntityHandle<T>>
+              createIndexedCollection(Persistence<EntityHandle<T>, ? extends Comparable> persistence) {
+        return new ConcurrentIndexedCollection<>(persistence);
     }
 
     @Override

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/MemoryIndexEngine.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/MemoryIndexEngine.java
@@ -7,9 +7,15 @@
  */
 package com.eventsourcing.index;
 
+import com.eventsourcing.Entity;
+import com.eventsourcing.EntityHandle;
 import com.eventsourcing.Repository;
 import com.eventsourcing.Journal;
+import com.googlecode.cqengine.ConcurrentIndexedCollection;
+import com.googlecode.cqengine.IndexedCollection;
 import com.googlecode.cqengine.attribute.Attribute;
+import com.googlecode.cqengine.attribute.MultiValueAttribute;
+import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.compound.CompoundIndex;
 import com.googlecode.cqengine.index.hash.HashIndex;
 import com.googlecode.cqengine.index.navigable.NavigableIndex;
@@ -18,10 +24,19 @@ import com.googlecode.cqengine.index.radixinverted.InvertedRadixTreeIndex;
 import com.googlecode.cqengine.index.radixreversed.ReversedRadixTreeIndex;
 import com.googlecode.cqengine.index.suffix.SuffixTreeIndex;
 import com.googlecode.cqengine.index.unique.UniqueIndex;
+import com.googlecode.cqengine.persistence.Persistence;
+import com.googlecode.cqengine.query.Query;
+import com.googlecode.cqengine.query.option.QueryOptions;
+import com.googlecode.cqengine.query.simple.Equal;
+import com.googlecode.cqengine.resultset.ResultSet;
 import org.osgi.service.component.annotations.Component;
 
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component(property = {"type=MemoryIndexEngine"})
 public class MemoryIndexEngine extends CQIndexEngine implements IndexEngine {
@@ -51,29 +66,161 @@ public class MemoryIndexEngine extends CQIndexEngine implements IndexEngine {
         return Arrays.asList(
                 new IndexCapabilities<Attribute>("Hash",
                                                  new IndexFeature[]{IndexFeature.EQ, IndexFeature.IN, IndexFeature.QZ},
-                                                 HashIndex::onAttribute),
+                                                 attr -> HashIndex.onAttribute(compatibleAttribute(attr))),
                 new IndexCapabilities<Attribute>("Unique",
                                                  new IndexFeature[]{IndexFeature.UNIQUE, IndexFeature.EQ, IndexFeature.IN},
-                                                 UniqueIndex::onAttribute),
+                                                 attr -> UniqueIndex.onAttribute(compatibleAttribute(attr))),
                 new IndexCapabilities<Attribute[]>("Compound",
                                                    new IndexFeature[]{IndexFeature.COMPOUND, IndexFeature.EQ, IndexFeature.IN, IndexFeature.QZ},
-                                                   CompoundIndex::onAttributes),
+                                                   attrs -> {
+                                                       Attribute[] attributes = (Attribute[]) Arrays.stream(attrs)
+                                                                                                    .map(attr -> compatibleAttribute(attr))
+                                                                                                    .toArray();
+                                                       return CompoundIndex.onAttributes(attributes);
+                                                   }),
                 new IndexCapabilities<Attribute>("Navigable",
                                                  new IndexFeature[]{IndexFeature.EQ, IndexFeature.IN, IndexFeature.QZ, IndexFeature.LT, IndexFeature.GT, IndexFeature.BT},
-                                                 NavigableIndex::onAttribute),
+                                                 attr -> NavigableIndex.onAttribute(compatibleAttribute(attr))),
                 new IndexCapabilities<Attribute>("RadixTree",
                                                  new IndexFeature[]{IndexFeature.EQ, IndexFeature.IN, IndexFeature.SW},
-                                                 RadixTreeIndex::onAttribute),
+                                                 attr -> RadixTreeIndex.onAttribute(compatibleAttribute(attr))),
                 new IndexCapabilities<Attribute>("ReversedRadixTree",
                                                  new IndexFeature[]{IndexFeature.EQ, IndexFeature.IN, IndexFeature.EW},
-                                                 ReversedRadixTreeIndex::onAttribute),
+                                                 attr -> ReversedRadixTreeIndex.onAttribute(compatibleAttribute(attr))),
                 new IndexCapabilities<Attribute>("InvertedRadixTree",
                                                  new IndexFeature[]{IndexFeature.EQ, IndexFeature.IN, IndexFeature.CI},
-                                                 InvertedRadixTreeIndex::onAttribute),
+                                                 attr -> InvertedRadixTreeIndex.onAttribute(compatibleAttribute(attr))),
                 new IndexCapabilities<Attribute>("SuffixTree",
                                                  new IndexFeature[]{IndexFeature.EQ, IndexFeature.IN, IndexFeature.EW, IndexFeature.SC},
-                                                 SuffixTreeIndex::onAttribute)
+                                                 attr -> SuffixTreeIndex.onAttribute(compatibleAttribute(attr)))
         );
 
+    }
+
+    @Override protected <T extends Entity> IndexedCollection<EntityHandle<T>>
+            createIndexedCollection(Persistence<EntityHandle<T>, ? extends Comparable> persistence) {
+        return new ConcurrentMemoryIndexedCollection<>(persistence);
+    }
+
+    private static class ConcurrentMemoryIndexedCollection<O> extends ConcurrentIndexedCollection<O> {
+        public ConcurrentMemoryIndexedCollection() {
+            super();
+        }
+
+        public ConcurrentMemoryIndexedCollection(
+                Persistence<O, ? extends Comparable> persistence) {
+            super(persistence);
+        }
+
+        @Override public ResultSet<O> retrieve(Query<O> query) {
+            return super.retrieve(compatibleQuery(query));
+        }
+
+        @Override public ResultSet<O> retrieve(Query<O> query, QueryOptions queryOptions) {
+            return super.retrieve(compatibleQuery(query), queryOptions);
+        }
+
+        private Query<O> compatibleQuery(Query<O> query) {
+            if (query instanceof Equal) {
+                if (((Equal) query).getAttributeType() == byte[].class) {
+                    Equal<O, Object> newQuery = new SpecialEquality<>(query);
+                    return newQuery;
+                }
+            }
+            return query;
+        }
+
+        private static class SpecialEquality<O> extends Equal<O, Object> {
+            public SpecialEquality(Query<O> query) {
+                super(compatibleAttribute(((Equal) query).getAttribute()), ((Equal) query).getValue());
+            }
+
+            @Override
+            protected boolean matchesNonSimpleAttribute(Attribute<O, Object> attribute, O object,
+                                                        QueryOptions queryOptions) {
+                for (Object attributeValue : attribute.getValues(object, queryOptions)) {
+                    if (attributeValue.equals(getValue())) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override public boolean equals(Object o) {
+                if (this == o) return true;
+                if (!(o instanceof Equal)) return false;
+
+                Equal equal = (Equal) o;
+
+                if (!equal.getAttribute().equals(getAttribute())) return false;
+                if (!equal.getValue().equals(getValue())) return false;
+                return true;
+            }
+        }
+    }
+
+    public static <O extends Entity, A> Attribute<EntityHandle<O>, ?> compatibleAttribute(Attribute<EntityHandle<O>, A>
+                                                                                       attribute) {
+        if (attribute.getAttributeType() == byte[].class) {
+            return new ByteArrayWrappingAttribute<>((Attribute<EntityHandle<O>, byte[]>) attribute);
+        } else {
+            return attribute;
+        }
+    }
+
+    private static class ByteArrayWrappingAttribute<O extends Entity>
+            extends MultiValueAttribute<EntityHandle<O>, ByteArray> {
+        private final Attribute<EntityHandle<O>, byte[]> attribute;
+
+        public ByteArrayWrappingAttribute(Attribute<EntityHandle<O>, byte[]> attribute) {
+            this.attribute = attribute;
+        }
+
+        @Override public String getAttributeName() {
+            return attribute.getAttributeName();
+        }
+
+        @Override public Iterable<ByteArray> getValues(EntityHandle<O> object, QueryOptions queryOptions) {
+            ArrayList<ByteArray> objects = new ArrayList<>();
+            Iterable<byte[]> values = attribute.getValues(object, queryOptions);
+            Iterator<byte[]> iterator = values.iterator();
+            while (iterator.hasNext()) {
+                objects.add(new ByteArray(iterator.next()));
+            }
+            return objects;
+        }
+
+        @Override public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            }
+            if (o.equals(attribute)) {
+                return true;
+            }
+            return super.equals(o);
+        }
+    }
+
+    private static class ByteArray implements Comparable {
+        private final byte[] bytes;
+
+        private ByteArray(byte[] bytes) {this.bytes = bytes;}
+
+        @Override public boolean equals(Object obj) {
+            if (!(obj instanceof byte[]) && !(obj instanceof ByteArray)) {
+                return false;
+            }
+            if (obj instanceof ByteArray) {
+                return ByteBuffer.wrap(bytes).equals(ByteBuffer.wrap(((ByteArray) obj).bytes));
+            }
+            return ByteBuffer.wrap(bytes).equals(ByteBuffer.wrap((byte[]) obj));
+        }
+
+        @Override public int compareTo(Object o) {
+            if (!(o instanceof byte[])) {
+                return -1;
+            }
+            return ByteBuffer.wrap(bytes).compareTo(ByteBuffer.wrap((byte[]) o));
+        }
     }
 }

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/MemoryHashIndexTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/MemoryHashIndexTest.java
@@ -8,11 +8,19 @@
 package com.eventsourcing.index;
 
 import com.eventsourcing.Entity;
+import com.eventsourcing.EntityHandle;
+import com.googlecode.cqengine.IndexedCollection;
 import com.googlecode.cqengine.index.hash.HashIndex;
+import com.googlecode.cqengine.persistence.onheap.OnHeapPersistence;
 
 public class MemoryHashIndexTest extends EqualityIndexTest<HashIndex> {
+
+    @Override public <O extends Entity> IndexedCollection<EntityHandle<O>> createIndexedCollection(Class<O> klass) {
+        return new MemoryIndexEngine().createIndexedCollection(new OnHeapPersistence());
+    }
+
     @Override
     public <A, O extends Entity> HashIndex onAttribute(Attribute<O, A> attribute) {
-        return HashIndex.onAttribute(attribute);
+        return HashIndex.onAttribute(MemoryIndexEngine.compatibleAttribute(attribute));
     }
 }

--- a/eventsourcing-h2/src/main/java/com/eventsourcing/h2/index/UniqueIndex.java
+++ b/eventsourcing-h2/src/main/java/com/eventsourcing/h2/index/UniqueIndex.java
@@ -202,7 +202,7 @@ public class UniqueIndex<A, O extends Entity> extends AbstractHashingAttributeIn
 
     public Val<A, O> decodeVal(byte[] bytes) {
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
-        A attr = attributeDeserializer.deserialize(buffer);
+        A attr = attributeDeserializer.deserialize(attrTypeHandler, buffer);
         O obj = objectDeserializer.deserialize(buffer);
         return new Val<>(attr, obj);
     }

--- a/eventsourcing-migrations/src/main/java/com/eventsourcing/migrations/LayoutMigration.java
+++ b/eventsourcing-migrations/src/main/java/com/eventsourcing/migrations/LayoutMigration.java
@@ -100,8 +100,7 @@ public class LayoutMigration<A extends Event, B extends Event> {
     private Optional<EntityLayoutIntroduced> layoutIntroduction(Repository repository, Layout<?> layout) {
         try (ResultSet<EntityHandle<EntityLayoutIntroduced>> resultSet = repository
                 .query(EntityLayoutIntroduced.class,
-                       equal(EntityLayoutIntroduced.FINGERPRINT, Base64.getEncoder().encodeToString(layout.getHash())
-                       ))) {
+                       equal(EntityLayoutIntroduced.FINGERPRINT, layout.getHash()))) {
             if (resultSet.isEmpty()) {
                 return Optional.empty();
             } else {

--- a/eventsourcing-migrations/src/main/java/com/eventsourcing/migrations/events/EntityLayoutIntroduced.java
+++ b/eventsourcing-migrations/src/main/java/com/eventsourcing/migrations/events/EntityLayoutIntroduced.java
@@ -11,19 +11,16 @@ import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Attribute;
-import com.eventsourcing.index.Indexing;
 import com.eventsourcing.index.SimpleAttribute;
 import com.eventsourcing.layout.Layout;
 import com.eventsourcing.layout.LayoutName;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.unprotocols.coss.RFC;
 import org.unprotocols.coss.Raw;
 
-import java.util.Base64;
 import java.util.Optional;
 
 import static com.eventsourcing.index.IndexEngine.IndexFeature.EQ;
@@ -51,11 +48,11 @@ public class EntityLayoutIntroduced extends StandardEvent {
     }
 
     @Index({EQ, UNIQUE})
-    public static Attribute<EntityLayoutIntroduced, String> FINGERPRINT =
-            new SimpleAttribute<EntityLayoutIntroduced, String>("fingerprint") {
+    public static Attribute<EntityLayoutIntroduced, byte[]> FINGERPRINT =
+            new SimpleAttribute<EntityLayoutIntroduced, byte[]>("fingerprint") {
         @Override
-        public String getValue(EntityLayoutIntroduced entityLayoutIntroduced, QueryOptions queryOptions) {
-            return Base64.getEncoder().encodeToString(entityLayoutIntroduced.fingerprint());
+        public byte[] getValue(EntityLayoutIntroduced entityLayoutIntroduced, QueryOptions queryOptions) {
+            return entityLayoutIntroduced.fingerprint();
         }
     };
 }

--- a/eventsourcing-repository/src/main/java/com/eventsourcing/repository/commands/IntroduceEntityLayouts.java
+++ b/eventsourcing-repository/src/main/java/com/eventsourcing/repository/commands/IntroduceEntityLayouts.java
@@ -55,8 +55,7 @@ public class IntroduceEntityLayouts extends StandardCommand<Lock, Void> {
         @Override public Stream<Event> apply(Class<? extends Entity> entity) {
         Layout<? extends Entity> layout = Layout.forClass(entity);
             byte[] fingerprint = layout.getHash();
-            Query<EntityHandle<EntityLayoutIntroduced>> query = equal(EntityLayoutIntroduced.FINGERPRINT,
-                                                                      Base64.getEncoder().encodeToString(fingerprint));
+            Query<EntityHandle<EntityLayoutIntroduced>> query = equal(EntityLayoutIntroduced.FINGERPRINT, fingerprint);
             try (ResultSet<EntityHandle<EntityLayoutIntroduced>> resultSet = repository
                     .query(EntityLayoutIntroduced.class,
                            query)) {


### PR DESCRIPTION
This prevents us from using byte[] in indices, especially such
core indices as EntityLayoutIntroduced.fingerprint.

Solution: handle byte[] as a special case

Also, change EntityLayoutIntroduced.fingerprint attribute
to byte[]