### PR TITLE
Problem: MemoryNavigableIndexTest not included into `gradle check` test plan

### DIFF
--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/MemoryNavigableIndexTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/MemoryNavigableIndexTest.java
@@ -11,7 +11,9 @@ import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.navigable.NavigableIndex;
 import com.googlecode.cqengine.quantizer.Quantizer;
+import org.testng.annotations.Test;
 
+@Test
 public class MemoryNavigableIndexTest extends NavigableIndexTest<NavigableIndex> {
 
     @Override


### PR DESCRIPTION
Solution: annotate MemoryNavigableIndexTest with `@Test` to include it