### PR TITLE
Problem: CEP events constructors require a timestamp

### DIFF
--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Deleted.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Deleted.java
@@ -13,6 +13,7 @@ import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Attribute;
 import com.eventsourcing.index.Indexing;
 import com.eventsourcing.index.SimpleAttribute;
+import com.eventsourcing.layout.LayoutConstructor;
 import com.eventsourcing.layout.LayoutName;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Builder;
@@ -50,6 +51,11 @@ public class Deleted extends StandardEvent {
             return deleted.timestamp();
         }
     };
+
+    @LayoutConstructor
+    public Deleted(UUID reference) {
+        this.reference = reference;
+    }
 
     @Builder
     public Deleted(UUID reference, HybridTimestamp timestamp) {

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/DescriptionChanged.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/DescriptionChanged.java
@@ -11,6 +11,7 @@ import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
+import com.eventsourcing.layout.LayoutConstructor;
 import com.eventsourcing.layout.LayoutName;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Builder;
@@ -34,6 +35,12 @@ public class DescriptionChanged extends StandardEvent {
     final UUID reference;
     @Getter
     final String description;
+
+    @LayoutConstructor
+    public DescriptionChanged(UUID reference, String description) {
+        this.reference = reference;
+        this.description = description;
+    }
 
     @Builder
     public DescriptionChanged(UUID reference, String description, HybridTimestamp timestamp) {

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/NameChanged.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/NameChanged.java
@@ -11,6 +11,7 @@ import com.eventsourcing.StandardEvent;
 import com.eventsourcing.annotations.Index;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
+import com.eventsourcing.layout.LayoutConstructor;
 import com.eventsourcing.layout.LayoutName;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Builder;
@@ -35,6 +36,12 @@ public class NameChanged extends StandardEvent {
     final UUID reference;
     @Getter
     final String name;
+
+    @LayoutConstructor
+    public NameChanged(UUID reference, String name) {
+        this.reference = reference;
+        this.name = name;
+    }
 
     @Builder
     public NameChanged(UUID reference, String name, HybridTimestamp timestamp) {

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Undeleted.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Undeleted.java
@@ -13,6 +13,7 @@ import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Attribute;
 import com.eventsourcing.index.Indexing;
 import com.eventsourcing.index.SimpleAttribute;
+import com.eventsourcing.layout.LayoutConstructor;
 import com.eventsourcing.layout.LayoutName;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Builder;
@@ -42,6 +43,11 @@ public class Undeleted extends StandardEvent {
             return undeleted.timestamp();
         }
     };
+
+    @LayoutConstructor
+    public Undeleted(UUID deleted) {
+        this.deleted = deleted;
+    }
 
     @Builder
     public Undeleted(UUID deleted, HybridTimestamp timestamp) {

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DeletedProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DeletedProtocolTest.java
@@ -45,6 +45,9 @@ public class DeletedProtocolTest extends RepositoryTest {
             this.id = id;
         }
 
+        public Delete(UUID id) {
+            this.id = id;
+        }
 
         @Override
         public EventStream<Void> events(Repository repository) throws Exception {
@@ -70,6 +73,11 @@ public class DeletedProtocolTest extends RepositoryTest {
             super(timestamp);
             this.id = id;
         }
+
+        public Undelete(UUID id) {
+            this.id = id;
+        }
+
 
         @Override
         public EventStream<Void> events(Repository repository) throws Exception {
@@ -102,7 +110,7 @@ public class DeletedProtocolTest extends RepositoryTest {
     public void deletion() {
         TestModel model = new TestModel(repository, UUID.randomUUID());
         assertFalse(model.deleted().isPresent());
-        Delete delete = Delete.builder().id(model.id()).build();
+        Delete delete = new Delete(model.id());
         repository.publish(delete).get();
         assertTrue(model.deleted().isPresent());
     }
@@ -110,9 +118,9 @@ public class DeletedProtocolTest extends RepositoryTest {
     @Test @SneakyThrows
     public void undeletion() {
         TestModel model = new TestModel(repository, UUID.randomUUID());
-        Delete delete = Delete.builder().id(model.id()).build();
+        Delete delete = new Delete(model.id());
         repository.publish(delete).get();
-        Undelete undelete = Undelete.builder().id(delete.eventId).build();
+        Undelete undelete = new Undelete(delete.eventId);
         repository.publish(undelete).get();
         assertFalse(model.deleted().isPresent());
     }

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DescriptionProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DescriptionProtocolTest.java
@@ -11,6 +11,7 @@ import com.eventsourcing.*;
 import com.eventsourcing.cep.events.DescriptionChanged;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.Repository;
+import com.eventsourcing.layout.LayoutConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -35,6 +36,12 @@ public class DescriptionProtocolTest extends RepositoryTest {
         private final UUID id;
         @Getter
         private final String description;
+
+        @LayoutConstructor
+        public ChangeDescription(UUID id, String description) {
+            this.id = id;
+            this.description = description;
+        }
 
         @Builder
         public ChangeDescription(HybridTimestamp timestamp, UUID id, String description) {
@@ -81,9 +88,7 @@ public class DescriptionProtocolTest extends RepositoryTest {
 
         TestModel model = new TestModel(repository, UUID.randomUUID());
 
-        ChangeDescription changeDescription = ChangeDescription.builder()
-                                                               .id(model.id())
-                                                               .description("Description #1").build();
+        ChangeDescription changeDescription = new ChangeDescription(model.id(), "Description #1");
         repository.publish(changeDescription).get();
         assertEquals(model.description(), "Description #1");
 
@@ -95,9 +100,7 @@ public class DescriptionProtocolTest extends RepositoryTest {
         assertEquals(model.description(), "Description #1"); // earlier change shouldn't affect the description
 
 
-        changeDescription = ChangeDescription.builder()
-                                             .id(model.id())
-                                             .description("Description #2").build();
+        changeDescription = new ChangeDescription(model.id(), "Description #2");
         repository.publish(changeDescription).get();
         assertEquals(model.description(), "Description #2");
     }

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/NameProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/NameProtocolTest.java
@@ -11,6 +11,7 @@ import com.eventsourcing.*;
 import com.eventsourcing.cep.events.NameChanged;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.Repository;
+import com.eventsourcing.layout.LayoutConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -35,6 +36,12 @@ public class NameProtocolTest extends RepositoryTest {
         private final UUID id;
         @Getter
         private final String name;
+
+        @LayoutConstructor
+        public Rename(UUID id, String name) {
+            this.id = id;
+            this.name = name;
+        }
 
         @Builder
         public Rename(HybridTimestamp timestamp, UUID id, String name) {
@@ -78,7 +85,7 @@ public class NameProtocolTest extends RepositoryTest {
 
         TestModel model = new TestModel(repository, UUID.randomUUID());
 
-        Rename rename = Rename.builder().id(model.id()).name("Name #1").build();
+        Rename rename = new Rename(model.id(), "Name #1");
         repository.publish(rename).get();
         assertEquals(model.name(), "Name #1");
 
@@ -88,7 +95,7 @@ public class NameProtocolTest extends RepositoryTest {
         assertEquals(model.name(), "Name #1"); // earlier change shouldn't affect the name
 
 
-        rename = Rename.builder().id(model.id()).name("Name #2").build();
+        rename = new Rename(model.id(), "Name #2");
         repository.publish(rename).get();
         assertEquals(model.name(), "Name #2");
     }


### PR DESCRIPTION
This requirement was imposed when Layout did not support
inherited properties.

Solution: expose constructors with events' own properties