### PR TITLE
Problem: PostgreSQL indices reinitialization breaks data constraints

### DIFF
--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/EqualityIndexTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/EqualityIndexTest.java
@@ -200,4 +200,33 @@ public abstract class EqualityIndexTest<HashIndex extends AttributeIndex> {
         cars.close();
         MANUFACTURER_INDEX.clear(noQueryOptions());
     }
+
+    @Test
+    public void reindexData() {
+        IndexedCollection<EntityHandle<Car>> collection = new ConcurrentIndexedCollection<>();
+        KeyStatisticsIndex<String, EntityHandle<Car>> MANUFACTURER_INDEX =
+                (KeyStatisticsIndex<String, EntityHandle<Car>>) onAttribute(Car.MANUFACTURER);
+        MANUFACTURER_INDEX.clear(noQueryOptions());
+
+        Set<EntityHandle<Car>> cars = CarFactory.createCollectionOfCars(10);
+
+        collection.addAll(cars);
+
+        collection.addIndex(MANUFACTURER_INDEX);
+
+        IndexedCollection<EntityHandle<Car>> collection1 = new ConcurrentIndexedCollection<>();
+        KeyStatisticsIndex<String, EntityHandle<Car>> MANUFACTURER_INDEX1 =
+                (KeyStatisticsIndex<String, EntityHandle<Car>>) onAttribute(Car.MANUFACTURER);
+
+        collection1.addAll(cars);
+
+        collection1.addIndex(MANUFACTURER_INDEX1);
+
+
+        assertEquals((int)MANUFACTURER_INDEX.getCountForKey("Honda", noQueryOptions()), 3);
+        assertEquals((int)MANUFACTURER_INDEX1.getCountForKey("Honda", noQueryOptions()), 3);
+
+        MANUFACTURER_INDEX.clear(noQueryOptions());
+        MANUFACTURER_INDEX1.clear(noQueryOptions());
+    }
 }

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/NavigableIndexTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/NavigableIndexTest.java
@@ -373,5 +373,33 @@ public abstract class NavigableIndexTest<NavigableIndex extends AttributeIndex &
 
     }
 
+    @Test
+    public void reindexData() {
+        IndexedCollection<EntityHandle<Car>> collection = new ConcurrentIndexedCollection<>();
+        KeyStatisticsIndex<Double, EntityHandle<Car>> PRICE_INDEX =
+                (KeyStatisticsIndex<Double, EntityHandle<Car>>) onAttribute(Car.PRICE);
+        PRICE_INDEX.clear(noQueryOptions());
+
+        Set<EntityHandle<Car>> cars = CarFactory.createCollectionOfCars(10);
+
+        collection.addAll(cars);
+
+        collection.addIndex(PRICE_INDEX);
+
+        IndexedCollection<EntityHandle<Car>> collection1 = new ConcurrentIndexedCollection<>();
+        KeyStatisticsIndex<Double, EntityHandle<Car>> PRICE_INDEX_1 =
+                (KeyStatisticsIndex<Double, EntityHandle<Car>>) onAttribute(Car.PRICE);
+
+        collection1.addAll(cars);
+
+        collection1.addIndex(PRICE_INDEX_1);
+
+
+        assertEquals((int)PRICE_INDEX.getCountForKey(9000.23, noQueryOptions()), 1);
+        assertEquals((int)PRICE_INDEX_1.getCountForKey(9000.23, noQueryOptions()), 1);
+
+        PRICE_INDEX.clear(noQueryOptions());
+        PRICE_INDEX_1.clear(noQueryOptions());
+    }
 
 }

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/EqualityIndex.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/EqualityIndex.java
@@ -87,7 +87,8 @@ public class EqualityIndex<A, O extends Entity> extends PostgreSQLAttributeIndex
             }
             String create = "CREATE TABLE IF NOT EXISTS " + getTableName() + " (" +
                     "\"key\" " + attributeType + ",\n" +
-                    "\"object\" UUID" +
+                    "\"object\" UUID,\n" +
+                    "PRIMARY KEY(\"key\", \"object\")" +
                     ")";
             try (PreparedStatement s = connection.prepareStatement(create)) {
                 s.executeUpdate();

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/NavigableIndex.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/NavigableIndex.java
@@ -108,7 +108,8 @@ public class NavigableIndex <A extends Comparable<A>, O extends Entity> extends 
             String attributeType = PostgreSQLSerialization.getMappedType(connection, attributeTypeHandler);
             String create = "CREATE TABLE IF NOT EXISTS " + tableName + " (" +
                     "\"key\" " + attributeType + ",\n" +
-                    "\"object\" UUID" +
+                    "\"object\" UUID," +
+                    "PRIMARY KEY(\"key\", \"object\")" +
                     ")";
             try (PreparedStatement s = connection.prepareStatement(create)) {
                 s.executeUpdate();

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/PostgreSQLAttributeIndex.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/PostgreSQLAttributeIndex.java
@@ -191,7 +191,9 @@ public abstract class PostgreSQLAttributeIndex<A, O extends Entity> extends Abst
         try(Connection connection = getDataSource().getConnection()) {
             connection.setAutoCommit(false);
             String insert = "INSERT INTO " + getTableName() + " VALUES (" + getParameter(connection, getAttributeTypeHandler(),
-                                                                                    null) + ", ?::UUID)";
+                                                                                    null) + ", ?::UUID) " +
+                    (queryOptions.get(OnConflictDo.class) == null ? "" :
+                            "ON CONFLICT DO " + queryOptions.get(OnConflictDo.class));
             try (PreparedStatement s = connection.prepareStatement(insert)) {
                 while (iterator.hasNext()) {
                     EntityHandle<O> object = iterator.next();
@@ -268,6 +270,7 @@ public abstract class PostgreSQLAttributeIndex<A, O extends Entity> extends Abst
         } else {
             this.keyObjectStore = new SetKeyObjectStore(objectStore, queryOptions);
         }
+        queryOptions.put(OnConflictDo.class, OnConflictDo.NOTHING);
         addAll(objectStore, queryOptions);
     }
 
@@ -615,6 +618,8 @@ public abstract class PostgreSQLAttributeIndex<A, O extends Entity> extends Abst
         return attributeValue;
     }
 
-
+    protected enum OnConflictDo {
+        UPDATE, NOTHING
+    }
 
 }


### PR DESCRIPTION
For example, `EqualityIndex` will re-add existing data, and `EqualityIndex`
with `unique` set will throw an exception.

Solution: establish row uniqueness guarantees and use PostgreSQL 9.5
ON CONFLICT DO NOTHING feature when appropriate