### PR TITLE
Problem: documentation uses explicit entity constructors

### DIFF
--- a/docs/core_concepts/command.md
+++ b/docs/core_concepts/command.md
@@ -8,9 +8,8 @@ Defining a command is pretty straightforward, through subclassing `StandardComma
 public class CreateUser extends StandardCommand<User, Void> {
   @Getter
   private final String email;
-  @Builder
-  public CreateUser(HybridTimestamp timestamp, String email) {
-    super(timestamp);
+
+  public CreateUser(String email) {
     this.email = email;
   }
 }
@@ -32,6 +31,6 @@ A more important part of any command is being able to generate events. This is d
 ```java
 @Override
 public EventStream<Void> events(Repository repository) {
-  return EventStream.of(UserCreated.builder().email(email).build());
+  return EventStream.of(new UserCreated(email));
 }
 ```

--- a/docs/core_concepts/event.md
+++ b/docs/core_concepts/event.md
@@ -11,9 +11,7 @@ public class UserCreated extends StandardEvent {
   @Getter
   private final String email;
 
-  @Builder
-  public UserCreated(HybridTimestamp timestamp, String email) {
-    super(timestamp);
+  public UserCreated(String email) {
     this.email = email;
   }
 }

--- a/docs/core_concepts/repository.md
+++ b/docs/core_concepts/repository.md
@@ -23,5 +23,5 @@ repository.startAsync().awaitRunning();
 Now we're ready to publish the command:
 
 ```java
-User result = repository.publish(CreateUser.builder().email("foo@bar.com").build()).get();
+User result = repository.publish(new CreateUser("foo@bar.com")).get();
 ```


### PR DESCRIPTION
This is no longer necessary.

Solution: update the documentation to use more succinct definitions