### PR TITLE
Problem: starting repository clocks are off in the future

### DIFF
--- a/eventsourcing-hlc/src/main/java/com/eventsourcing/hlc/HybridTimestamp.java
+++ b/eventsourcing-hlc/src/main/java/com/eventsourcing/hlc/HybridTimestamp.java
@@ -13,6 +13,8 @@ import com.eventsourcing.layout.SerializableComparable;
 import lombok.Getter;
 import org.apache.commons.net.ntp.TimeStamp;
 
+import java.util.Date;
+
 /**
  * HybridTimestamp implements <a href="http://www.cse.buffalo.edu/tech-reports/2014-04.pdf">Hybrid Logical Clock</a>,
  * currently heavily inspired by a corresponding <a href="https://github.com/tschottdorf/hlc-rs">Rust library</a>.
@@ -28,11 +30,11 @@ public class HybridTimestamp implements Comparable<HybridTimestamp>, Serializabl
     long logicalCounter;
 
     public HybridTimestamp() {
-        this(null, 0, 0);
+        this(null);
     }
 
     public HybridTimestamp(PhysicalTimeProvider physicalTimeProvider) {
-        this(physicalTimeProvider, 0, 0);
+        this(physicalTimeProvider, new TimeStamp(new Date(0)).ntpValue(), 0);
     }
 
     public HybridTimestamp(PhysicalTimeProvider physicalTimeProvider, long timestamp) {
@@ -118,8 +120,7 @@ public class HybridTimestamp implements Comparable<HybridTimestamp>, Serializabl
      * @return updated timestamp
      */
     public long update(HybridTimestamp ts) {
-        long timestamp = ts.timestamp();
-        return update(timestamp >> 16, timestamp << 48 >> 48);
+        return update(ts.getLogicalTime(), ts.getLogicalCounter());
     }
 
     /**

--- a/eventsourcing-hlc/src/test/java/com/eventsourcing/hlc/HybridTimestampTest.java
+++ b/eventsourcing-hlc/src/test/java/com/eventsourcing/hlc/HybridTimestampTest.java
@@ -16,10 +16,12 @@ import com.eventsourcing.layout.Property;
 import com.eventsourcing.layout.binary.ObjectBinarySerializer;
 import com.google.common.util.concurrent.AbstractService;
 import lombok.SneakyThrows;
+import org.apache.commons.net.ntp.TimeStamp;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Date;
 import java.util.List;
 
 import static org.testng.Assert.assertEquals;
@@ -60,6 +62,13 @@ public class HybridTimestampTest {
     }
 
     @Test
+    public void initialTimestamp() {
+        HybridTimestamp timestamp = new HybridTimestamp(physicalTimeProvider);
+        TimeStamp ntpTime = new TimeStamp(timestamp.getLogicalTime());
+        assertEquals(ntpTime.getDate(), new Date(0));
+    }
+
+    @Test
     public void testTimestamp() {
         HybridTimestamp timestamp = new HybridTimestamp(physicalTimeProvider);
         timestamp.update();
@@ -97,7 +106,7 @@ public class HybridTimestampTest {
     @Test
     public void test() {
         long ts, ts_;
-        HybridTimestamp timestamp = new HybridTimestamp(physicalTimeProvider);
+        HybridTimestamp timestamp = new HybridTimestamp(physicalTimeProvider, 0, 0);
 
         ts = (long) 1 << 32 | 0;
         physicalTimeProvider.setPhysicalTime(ts);

--- a/eventsourcing-repository/src/main/java/com/eventsourcing/repository/CommandConsumerImpl.java
+++ b/eventsourcing-repository/src/main/java/com/eventsourcing/repository/CommandConsumerImpl.java
@@ -218,6 +218,7 @@ class CommandConsumerImpl extends AbstractService implements CommandConsumer {
         this.indexEngine = indexEngine;
         this.lockProvider = lockProvider;
         this.timestamp = new HybridTimestamp(timeProvider);
+        timestamp.update();
         for (Class<? extends Command> cmd : commandClasses) {
             Layout<? extends Command> layout = Layout.forClass(cmd);
             layouts.put(cmd, layout);


### PR DESCRIPTION
Solution: fix a bug in HybridTimestamp

Updating a HybridTimestamp with another HybridTimestamp mistakenly re-processed
logical time and counter and sent the clocks off the future upon initial timestamp
updates with initial commands.