### PR TITLE
Problem: repeating the snippet for retrieving last entity is a nuisance

### DIFF
--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/protocols/DescriptionProtocol.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/protocols/DescriptionProtocol.java
@@ -7,27 +7,22 @@
  */
 package com.eventsourcing.cep.protocols;
 
-import com.eventsourcing.EntityHandle;
 import com.eventsourcing.Protocol;
+import com.eventsourcing.queries.ModelQueries;
 import com.eventsourcing.cep.events.DescriptionChanged;
-import com.googlecode.cqengine.query.option.EngineThresholds;
-import com.googlecode.cqengine.resultset.ResultSet;
 import org.unprotocols.coss.Draft;
 import org.unprotocols.coss.RFC;
 
-import static com.googlecode.cqengine.query.QueryFactory.*;
+import java.util.Optional;
 
 @Draft @RFC(url = "http://rfc.eventsourcing.com/spec:3/CEP")
-public interface DescriptionProtocol extends Protocol {
+public interface DescriptionProtocol extends Protocol, ModelQueries {
     default String description() {
-        try (ResultSet<EntityHandle<DescriptionChanged>> resultSet =
-                     getRepository().query(DescriptionChanged.class, equal(DescriptionChanged.REFERENCE_ID, getId()),
-                                           queryOptions(orderBy(descending(DescriptionChanged.TIMESTAMP)),
-                                                        applyThresholds(threshold(EngineThresholds.INDEX_ORDERING_SELECTIVITY, 0.5))))) {
-            if (resultSet.isEmpty()) {
-                return null;
-            }
-            return resultSet.iterator().next().get().description();
+        Optional<DescriptionChanged> last = latestAssociatedEntity(DescriptionChanged.class, DescriptionChanged.REFERENCE_ID, DescriptionChanged.TIMESTAMP);
+        if (last.isPresent()) {
+            return last.get().description();
+        } else {
+            return null;
         }
     }
 }

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/protocols/NameProtocol.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/protocols/NameProtocol.java
@@ -7,27 +7,22 @@
  */
 package com.eventsourcing.cep.protocols;
 
-import com.eventsourcing.EntityHandle;
 import com.eventsourcing.Protocol;
+import com.eventsourcing.queries.ModelQueries;
 import com.eventsourcing.cep.events.NameChanged;
-import com.googlecode.cqengine.query.option.EngineThresholds;
-import com.googlecode.cqengine.resultset.ResultSet;
 import org.unprotocols.coss.Draft;
 import org.unprotocols.coss.RFC;
 
-import static com.googlecode.cqengine.query.QueryFactory.*;
+import java.util.Optional;
 
 @Draft @RFC(url = "http://rfc.eventsourcing.com/spec:3/CEP")
-public interface NameProtocol extends Protocol {
+public interface NameProtocol extends Protocol, ModelQueries {
     default String name() {
-        try (ResultSet<EntityHandle<NameChanged>> resultSet =
-                     getRepository().query(NameChanged.class, equal(NameChanged.REFERENCE_ID, getId()),
-                                      queryOptions(orderBy(descending(NameChanged.TIMESTAMP)),
-                                                   applyThresholds(threshold(EngineThresholds.INDEX_ORDERING_SELECTIVITY, 0.5))))) {
-            if (resultSet.isEmpty()) {
-                return null;
-            }
-            return resultSet.iterator().next().get().name();
+        Optional<NameChanged> last = latestAssociatedEntity(NameChanged.class, NameChanged.REFERENCE_ID, NameChanged.TIMESTAMP);
+        if (last.isPresent()) {
+            return last.get().name();
+        } else {
+            return null;
         }
     }
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/Protocol.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/Protocol.java
@@ -47,7 +47,7 @@ package com.eventsourcing;
  * </pre>
  * <p>
  * <p>
- * The above protocol implements a {@code name()} function that retrieves the last {@code NameChange} for the particular
+ * The above protocol implements a {@code name()} function that retrieves the latestAssociatedEntity {@code NameChange} for the particular
  * model referenced by its UUID ({@code getId()}).
  * <p>
  * Now, all we have to do is to make every model implement this interface:

--- a/eventsourcing-core/src/main/java/com/eventsourcing/queries/LatestAssociatedEntryQuery.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/queries/LatestAssociatedEntryQuery.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.queries;
+
+import com.eventsourcing.Entity;
+import com.eventsourcing.EntityHandle;
+import com.eventsourcing.Model;
+import com.eventsourcing.hlc.HybridTimestamp;
+import com.eventsourcing.index.Attribute;
+import com.googlecode.cqengine.query.Query;
+import com.googlecode.cqengine.query.option.EngineThresholds;
+import com.googlecode.cqengine.resultset.ResultSet;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.googlecode.cqengine.query.QueryFactory.*;
+
+/**
+ * Provides a query for retrieving the latest entry, associated with a model. For example,
+ * to retrieve the latest e-mail change:
+ *
+ * <code>
+ *     latestAssociatedEntity(EmailChanged.class, EmailChanged.REFERENCE_ID, EmailChanged.TIMESTAMP)
+ * </code>
+ */
+public interface LatestAssociatedEntryQuery extends Model {
+
+    /**
+     * Invokes {@link #latestAssociatedEntity(Class, Attribute, Attribute, Query[])} with no additional queries
+     *
+     * @param klass Entity class
+     * @param keyAttribute Entity attribute that references model's ID
+     * @param timestampAttribute Entity attribute that holds the timestamp
+     * @param <T> Entity type
+     * @return Non-empty {@link Optional} if the entity is found, an empty one otherwise.
+     */
+    default <T extends Entity> Optional<T> latestAssociatedEntity(Class<T> klass,
+                                                                  Attribute<T, UUID> keyAttribute,
+                                                                  Attribute<T, HybridTimestamp> timestampAttribute) {
+        @SuppressWarnings("unchecked")
+        Optional<T> last = latestAssociatedEntity(klass, keyAttribute, timestampAttribute, (Query<EntityHandle<T>>[]) new Query[]{});
+        return last;
+    }
+
+    /**
+     * Invokes {@link #latestAssociatedEntity(Class, Attribute, Attribute, Query[])} with one additional query
+     * @param klass Entity class
+     * @param keyAttribute Entity attribute that references model's ID
+     * @param timestampAttribute Entity attribute that holds the timestamp
+     * @param additionalQuery An additional condition
+     * @param <T> Entity type
+     * @return Non-empty {@link Optional} if the entity is found, an empty one otherwise.
+     */
+    default <T extends Entity> Optional<T> latestAssociatedEntity(Class<T> klass,
+                                                                  Attribute<T, UUID> keyAttribute,
+                                                                  Attribute<T, HybridTimestamp> timestampAttribute,
+                                                                  Query<EntityHandle<T>> additionalQuery
+    ) {
+        @SuppressWarnings("unchecked")
+        Optional<T> last = latestAssociatedEntity(klass, keyAttribute, timestampAttribute, (Query<EntityHandle<T>>[]) new Query[]{additionalQuery});
+        return last;
+    }
+
+    /**
+     * Queries the latest entity associated with the model. For example,
+     * to retrieve the latest e-mail change:
+     *
+     * <code>
+     *     latestAssociatedEntity(EmailChanged.class, EmailChanged.REFERENCE_ID, EmailChanged.TIMESTAMP)
+     * </code>
+     *
+     * If additional conditions are required, they can be added to the end of the method call:
+     *
+     * <code>
+     *     latestAssociatedEntity(EmailChanged.class, EmailChanged.REFERENCE_ID, EmailChanged.TIMESTAMP,
+     *                            equal(EmailChanged.APPROVED, true))
+     * </code>
+     *
+     * @param klass Entity class
+     * @param keyAttribute Entity attribute that references model's ID
+     * @param timestampAttribute Entity attribute that holds the timestamp
+     * @param additionalQueries Additional conditions
+     * @param <T> Entity type
+     * @return Non-empty {@link Optional} if the entity is found, an empty one otherwise.
+     */
+    default <T extends Entity> Optional<T>
+    latestAssociatedEntity(Class<T> klass,
+                           Attribute<T, UUID> keyAttribute, Attribute<T, HybridTimestamp> timestampAttribute,
+                           Query<EntityHandle<T>> ...additionalQueries) {
+        Query<EntityHandle<T>> query = equal(keyAttribute, getId());
+        for (Query<EntityHandle<T>> q : additionalQueries) {
+            query = and(query, q);
+        }
+        try (ResultSet<EntityHandle<T>> resultSet = getRepository()
+                .query(klass, query,
+                       queryOptions(orderBy(descending(timestampAttribute)),
+                                    applyThresholds(threshold(EngineThresholds.INDEX_ORDERING_SELECTIVITY, 0.5))))) {
+            if (resultSet.isEmpty()) {
+                return Optional.empty();
+            } else {
+                return Optional.of(resultSet.iterator().next().get());
+            }
+        }
+    }
+
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/queries/ModelQueries.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/queries/ModelQueries.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.queries;
+
+import com.eventsourcing.Model;
+
+/**
+ * Combines all standard queries into one:
+ * <ul>
+ *     <li>{@link LatestAssociatedEntryQuery}</li>
+ * </ul>
+ */
+public interface ModelQueries extends Model, LatestAssociatedEntryQuery {}


### PR DESCRIPTION
Not only this is error-prone, it also adds a considerable amount of noise.

Solution: Extract com.eventsourcing.queries.ModelQueries interface that
provides this functionality by including LatestAssociatedEntryQuery
interface, which implements the `#latestAssociatedEntity` method.