### PR TITLE
Problem: querying for latest entities across a broader condition is difficult

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/EntityQueryFactory.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/EntityQueryFactory.java
@@ -16,9 +16,9 @@ import com.googlecode.cqengine.query.simple.SimpleQuery;
 
 import java.util.Collections;
 
-public class EntityQueryFactory {
+public interface EntityQueryFactory {
 
-    public static class All<O extends Entity> extends SimpleQuery<EntityHandle<O>, O> {
+    class All<O extends Entity> extends SimpleQuery<EntityHandle<O>, O> {
 
         final Class<O> attributeType;
 
@@ -89,7 +89,7 @@ public class EntityQueryFactory {
      * @param <O> The type of the objects in the collection
      * @return A query which matches all objects in the collection
      */
-    public static <O extends Entity> Query<EntityHandle<O>> all(Class<O> objectType) {
+    static <O extends Entity> Query<EntityHandle<O>> all(Class<O> objectType) {
         return new All<>(objectType);
     }
 

--- a/eventsourcing-queries/src/main/java/com/eventsourcing/queries/IsLatestEntity.java
+++ b/eventsourcing-queries/src/main/java/com/eventsourcing/queries/IsLatestEntity.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.queries;
+
+import com.eventsourcing.EntityHandle;
+import com.eventsourcing.hlc.HybridTimestamp;
+import com.googlecode.cqengine.IndexedCollection;
+import com.googlecode.cqengine.attribute.Attribute;
+import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.query.Query;
+import com.googlecode.cqengine.query.logical.Or;
+import com.googlecode.cqengine.query.option.QueryOptions;
+import com.googlecode.cqengine.query.simple.SimpleQuery;
+import com.googlecode.cqengine.resultset.ResultSet;
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static com.googlecode.cqengine.query.QueryFactory.*;
+
+
+/**
+ * IsLatestEntity filters for entities that are the most recent against a queryFunction.
+ *
+ * For example, to query the latest NameChanged across all entities:
+ *
+ * <code>
+ *     isLatestEntity(repository.getIndexEngine().getIndexedCollection(NameChanged.class),
+ *                    (h) -&gt; equal(NameChanged.REFERENCE_ID, h.get().reference()),
+ *                    NameChanged.TIMESTAMP)
+ * </code>
+ *
+ * @see QueryFactory#isLatestEntity(IndexedCollection, Function, Attribute)
+ * @see QueryFactory#isLatestEntity(IndexedCollection, Query, Attribute)
+ *
+ * @param <O>
+ */
+public class IsLatestEntity<O extends EntityHandle> extends SimpleQuery<O, HybridTimestamp> {
+
+    private final IndexedCollection<O> collection;
+    private final Attribute<O, HybridTimestamp> timestampAttribute;
+    private Function<O, Query<O>> queryFunction;
+    private Query<O> query;
+
+    /**
+     * @param collection collection to query against
+     * @param queryFunction query returning function
+     * @param timestampAttribute timestamp attribute.
+     */
+    public IsLatestEntity(IndexedCollection<O> collection,
+                          Function<O, Query<O>> queryFunction,
+                          Attribute<O, HybridTimestamp> timestampAttribute) {
+        super(timestampAttribute);
+        this.collection = collection;
+        this.queryFunction = queryFunction;
+        this.timestampAttribute = timestampAttribute;
+    }
+
+    /**
+     * @param collection collection to query against
+     * @param query query
+     * @param timestampAttribute timestamp attribute.
+     */
+    public IsLatestEntity(IndexedCollection<O> collection,
+                          Query<O> query,
+                          Attribute<O, HybridTimestamp> timestampAttribute) {
+        super(timestampAttribute);
+        this.collection = collection;
+        this.query = query;
+        this.timestampAttribute = timestampAttribute;
+    }
+
+    @Value
+    @Accessors(fluent = true)
+    private static class TerminatedRecords<O> {
+        private Map<Query<O>, UUID> queries = new HashMap<>();
+    }
+
+    private Optional<Boolean> terminatedQuery(O object, Query<O> query, QueryOptions queryOptions) {
+        if (queryOptions.get(TerminatedRecords.class) == null) {
+            queryOptions.put(TerminatedRecords.class, new TerminatedRecords<>());
+        }
+        TerminatedRecords terminatedRecords = queryOptions.get(TerminatedRecords.class);
+        UUID record = (UUID) terminatedRecords.queries().get(query);
+        if (record == null) {
+            return Optional.empty();
+        }
+        return Optional.of(record == object.uuid());
+    }
+
+    private boolean matches(ResultSet<O> resultSet, Query<O> query, O object, QueryOptions queryOptions) {
+        boolean matches = resultSet.size() == 0;
+        if (matches) {
+            @SuppressWarnings("unchecked")
+            TerminatedRecords<O> terminatedRecords = queryOptions.get(TerminatedRecords.class);
+            terminatedRecords.queries().put(query, object.uuid());
+        }
+        return matches;
+    }
+
+    @Override
+    protected boolean matchesSimpleAttribute(SimpleAttribute<O, HybridTimestamp> attribute, O object, QueryOptions
+            queryOptions) {
+        Query<O> actualQuery = query == null ? queryFunction.apply(object) : query;
+        Optional<Boolean> terminatedQuery = terminatedQuery(object, actualQuery, queryOptions);
+        if (terminatedQuery.isPresent()) {
+            return terminatedQuery.get();
+        }
+        HybridTimestamp value = attribute.getValue(object, queryOptions);
+        try (ResultSet<O> resultSet = collection.retrieve(and(
+                actualQuery,
+                greaterThan(timestampAttribute, value)))) {
+            return matches(resultSet, actualQuery, object, queryOptions);
+        }
+    }
+
+    @Override
+    protected boolean matchesNonSimpleAttribute(Attribute<O, HybridTimestamp> attribute, O object, QueryOptions
+            queryOptions) {
+        Query<O> actualQuery = query == null ? queryFunction.apply(object) : query;
+        Optional<Boolean> terminatedQuery = terminatedQuery(object, actualQuery, queryOptions);
+        if (terminatedQuery.isPresent()) {
+            return terminatedQuery.get();
+        }
+        Iterable<HybridTimestamp> values = attribute.getValues(object, queryOptions);
+        List<Query<O>> conditions = StreamSupport.stream(values.spliterator(), false)
+                                                 .map(v -> greaterThan(timestampAttribute, v))
+                                                 .collect(Collectors.toList());
+        Query<O> timestampQuery = new Or<>(conditions);
+        try (ResultSet<O> resultSet = collection.retrieve(and(
+                actualQuery,
+                timestampQuery))) {
+            return matches(resultSet, actualQuery, object, queryOptions);
+        }
+    }
+
+    @Override protected int calcHashCode() {
+        int result = collection.hashCode();
+        result = 31 * result + (query == null ? queryFunction : query).hashCode();
+        result = 31 * result + timestampAttribute.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "isLatestEntity(" +
+                "IndexedCollection<" + timestampAttribute.getObjectType().getSimpleName() + ">" +
+                ", query=" + query == null ? queryFunction.toString() : query +
+                ", timestamp=" + asLiteral(timestampAttribute.getAttributeName()) +
+                ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IsLatestEntity)) return false;
+
+        IsLatestEntity latestReference = (IsLatestEntity) o;
+
+        if (!collection.equals(latestReference.collection)) return false;
+        if (query != null && !query.equals(query)) return false;
+        if (queryFunction != null && !queryFunction.equals(latestReference.queryFunction)) return false;
+        if (!timestampAttribute.equals(latestReference.timestampAttribute)) return false;
+
+        return true;
+    }
+}

--- a/eventsourcing-queries/src/main/java/com/eventsourcing/queries/ModelQueries.java
+++ b/eventsourcing-queries/src/main/java/com/eventsourcing/queries/ModelQueries.java
@@ -11,7 +11,10 @@ import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
 import com.eventsourcing.Model;
 import com.eventsourcing.Repository;
+import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Attribute;
+import com.googlecode.cqengine.IndexedCollection;
+import com.googlecode.cqengine.query.Query;
 import com.googlecode.cqengine.resultset.ResultSet;
 
 import java.util.Optional;
@@ -47,4 +50,5 @@ public interface ModelQueries extends Model, LatestAssociatedEntryQuery {
             }
         }
     }
+
 }

--- a/eventsourcing-queries/src/main/java/com/eventsourcing/queries/QueryFactory.java
+++ b/eventsourcing-queries/src/main/java/com/eventsourcing/queries/QueryFactory.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.queries;
+
+import com.eventsourcing.Entity;
+import com.eventsourcing.EntityHandle;
+import com.eventsourcing.hlc.HybridTimestamp;
+import com.eventsourcing.index.EntityQueryFactory;
+import com.googlecode.cqengine.IndexedCollection;
+import com.googlecode.cqengine.query.Query;
+
+import java.util.function.Function;
+
+public class QueryFactory implements EntityQueryFactory {
+    /**
+     * @see LatestAssociatedEntryQuery
+     * @param collection collection to query against
+     * @param query query as is
+     * @param timestampAttribute timestamp attribute
+     * @param <O> entity type
+     * @return a query
+     */
+    public static <O extends Entity> Query<EntityHandle<O>>
+    isLatestEntity(final IndexedCollection<EntityHandle<O>> collection,
+                   final Query<EntityHandle<O>> query,
+                   final com.googlecode.cqengine.attribute.Attribute<EntityHandle<O>, HybridTimestamp> timestampAttribute) {
+        return new IsLatestEntity<>(collection, query, timestampAttribute);
+    }
+
+    /**
+     * @see LatestAssociatedEntryQuery
+     * @param collection collection to query against
+     * @param query query returning function
+     * @param timestampAttribute timestamp attribute
+     * @param <O> entity type
+     * @return a query
+     */
+    public static <O extends Entity> Query<EntityHandle<O>>
+    isLatestEntity(final IndexedCollection<EntityHandle<O>> collection,
+                   final Function<EntityHandle<O>, Query<EntityHandle<O>>> query,
+                   final com.googlecode.cqengine.attribute.Attribute<EntityHandle<O>, HybridTimestamp> timestampAttribute) {
+        return new IsLatestEntity<>(collection, query, timestampAttribute);
+    }
+}

--- a/eventsourcing-queries/src/test/java/com/eventsourcing/queries/IsLatestEntityTest.java
+++ b/eventsourcing-queries/src/test/java/com/eventsourcing/queries/IsLatestEntityTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.queries;
+
+import com.eventsourcing.*;
+import com.eventsourcing.annotations.Index;
+import com.eventsourcing.hlc.HybridTimestamp;
+import com.eventsourcing.index.IndexEngine;
+import com.eventsourcing.index.SimpleAttribute;
+import com.google.common.collect.Iterators;
+import com.googlecode.concurrenttrees.common.Iterables;
+import com.googlecode.cqengine.IndexedCollection;
+import com.googlecode.cqengine.query.Query;
+import com.googlecode.cqengine.query.option.QueryOptions;
+import com.googlecode.cqengine.resultset.ResultSet;
+import lombok.EqualsAndHashCode;
+import lombok.SneakyThrows;
+import lombok.Value;
+import lombok.experimental.Accessors;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static com.eventsourcing.index.IndexEngine.IndexFeature.*;
+import static com.eventsourcing.queries.QueryFactory.isLatestEntity;
+import static com.googlecode.cqengine.query.QueryFactory.equal;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class IsLatestEntityTest extends RepositoryUsingTest {
+
+    public IsLatestEntityTest() {
+        super(IsLatestEntityTest.class.getPackage());
+    }
+
+
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    @Accessors(fluent = true)
+    public static class TestEvent extends StandardEvent {
+        private String test;
+        private UUID reference;
+        @Index
+        public static SimpleAttribute<TestEvent, UUID> REFERENCE_ID = new
+                SimpleAttribute<TestEvent, UUID>("uuid") {
+            @Override public UUID getValue(TestEvent object, QueryOptions queryOptions) {
+                return object.reference();
+            }
+        };
+        @Index({EQ, LT, GT})
+        public static SimpleAttribute<TestEvent, HybridTimestamp> TIMESTAMP = new
+                SimpleAttribute<TestEvent, HybridTimestamp>("timestamp") {
+                    @Override public HybridTimestamp getValue(TestEvent object, QueryOptions queryOptions) {
+                        return object.timestamp();
+                    }
+        };
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    @Accessors(fluent = true)
+    public static class TestCommand extends StandardCommand<Void, UUID> {
+        private String test;
+        private UUID reference;
+
+        @Override public EventStream<Void> events(Repository repository) throws Exception {
+            TestEvent event = new TestEvent(test, reference);
+            return EventStream.of(event);
+        }
+
+        @Override public UUID result() {
+            return reference;
+        }
+    }
+
+    @Test @SneakyThrows
+    public void test() {
+        UUID uuid = UUID.randomUUID();
+        repository.publish(new TestCommand("test1", uuid)).get();
+        IndexedCollection<EntityHandle<TestEvent>> coll = repository.getIndexEngine().getIndexedCollection
+                (TestEvent.class);
+        Query<EntityHandle<TestEvent>> query = isLatestEntity(coll, equal(TestEvent.REFERENCE_ID, uuid),
+                                                              TestEvent.TIMESTAMP);
+        try (ResultSet<EntityHandle<TestEvent>> resultSet = repository.query(TestEvent.class, query)) {
+            assertEquals(resultSet.size(), 1);
+            assertEquals(resultSet.uniqueResult().get().test(), "test1");
+        }
+        repository.publish(new TestCommand("test2", uuid)).get();
+        try (ResultSet<EntityHandle<TestEvent>> resultSet = repository.query(TestEvent.class, query)) {
+            assertEquals(resultSet.size(), 1);
+            assertEquals(resultSet.uniqueResult().get().test(), "test2");
+        }
+    }
+
+    @Test @SneakyThrows
+    public void testMassive() {
+        UUID uuid = UUID.randomUUID();
+        for (int i = 0; i < 10000; i++ ) {
+            repository.publish(new TestCommand("test" + (i + 1), uuid)).get();
+        }
+        IndexedCollection<EntityHandle<TestEvent>> coll = repository.getIndexEngine().getIndexedCollection
+                (TestEvent.class);
+
+        Query<EntityHandle<TestEvent>> query = isLatestEntity(coll, equal(TestEvent.REFERENCE_ID, uuid),
+                                                              TestEvent.TIMESTAMP);
+        long t1 = System.nanoTime();
+        try (ResultSet<EntityHandle<TestEvent>> resultSet = repository.query(TestEvent.class, query)) {
+            assertEquals(resultSet.size(), 1);
+            assertEquals(resultSet.uniqueResult().get().test(), "test10000");
+            long t2 = System.nanoTime();
+            long time = TimeUnit.SECONDS.convert(t2 - t1, TimeUnit.NANOSECONDS);
+            if (time > 1) {
+                System.err.println("Warning: [IsLatestEntityTest.testMassive] isLatestEntity is slow, took " + time +
+                                           " seconds");
+            }
+        }
+    }
+
+    @Test @SneakyThrows
+    public void testFunction() {
+        UUID uuid = UUID.randomUUID();
+        repository.publish(new TestCommand("test1", uuid)).get();
+        repository.publish(new TestCommand("test2", uuid)).get();
+        UUID uuidN = UUID.randomUUID();
+        repository.publish(new TestCommand("testN1", uuidN)).get();
+        repository.publish(new TestCommand("testN2", uuidN)).get();
+
+        IndexedCollection<EntityHandle<TestEvent>> coll = repository.getIndexEngine().getIndexedCollection
+                (TestEvent.class);
+        Query<EntityHandle<TestEvent>> query = isLatestEntity(coll,
+                                                              (h) -> equal(TestEvent.REFERENCE_ID, h.get().reference()),
+                                                              TestEvent.TIMESTAMP);
+        try (ResultSet<EntityHandle<TestEvent>> resultSet = repository.query(TestEvent.class, query)) {
+            assertEquals(resultSet.size(), 2);
+            List<EntityHandle<TestEvent>> result = Iterables.toList(resultSet);
+            assertTrue(Iterators.any(result.iterator(), e -> e.get().test().contentEquals("test2")));
+            assertTrue(Iterators.any(result.iterator(), e -> e.get().test().contentEquals("testN2")));
+        }
+    }
+}


### PR DESCRIPTION
The type of query would be "give me the latest instance of NameChanged of all
NameChanged related to a Person"

Solution: introduce a specialy IsLatestEntity query

Now it is possible to write something like this:

```java
Query<EntityHandle<NameChanged>> isPerson = existsIn(
                repository.getIndexEngine().getIndexedCollection(PersonRegistered.class),
                NameChanged.REFERENCE_ID, PersonRegistered.ID);
Query<EntityHandle<NameChanged>> latestEntity =
                isLatestEntity(repository.getIndexEngine().getIndexedCollection(NameChanged.class),
                                (v) -> equal(NameChanged.REFERENCE_ID, v.get().reference()),
                               NameChanged.TIMESTAMP);
Query<EntityHandle<NameChanged>> query = and(latestEntity, isPerson);
```

Please note that it is quite slow so far. Hoping we can get a more efficient solution.