### PR TITLE
Problem: cqengine refuses to add more indices

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/AbstractAttribute.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/AbstractAttribute.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.index;
+
+import com.eventsourcing.Entity;
+import com.eventsourcing.EntityHandle;
+
+public abstract class AbstractAttribute<O extends Entity, A>
+        extends com.googlecode.cqengine.attribute.support.AbstractAttribute<EntityHandle<O>, A>
+        implements Attribute<O, A> {
+
+    private Class<O> objectType;
+    private int cachedHashCode;
+
+    public AbstractAttribute() {
+        super();
+    }
+
+    public AbstractAttribute(String attributeName) {
+        super(attributeName);
+    }
+
+    public AbstractAttribute(Class<O> objectType, Class<EntityHandle<O>> handleType, Class<A> attributeType) {
+        super(handleType, attributeType);
+        this.objectType = objectType;
+        cachedHashCode = calcHashCode();
+    }
+
+    public AbstractAttribute(Class<O> objectType, Class<EntityHandle<O>> handleType, Class<A> attributeType, String attributeName) {
+        super(handleType, attributeType, attributeName);
+        this.objectType = objectType;
+    }
+
+    @Override public Class<O> getEffectiveObjectType() {
+        return objectType == null ? Attribute.readGenericObjectType(getClass(), getAttributeName()) : objectType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AbstractAttribute)) return false;
+
+        AbstractAttribute that = (AbstractAttribute) o;
+
+        // TODO: reinstate this cachedHashCode comparison once EqualsVerifier supports cached hash code "shortcut":
+        //if (cachedHashCode != that.cachedHashCode) return false;
+        if (!that.canEqual(this)) return false;
+        if (!getAttributeName().equals(that.getAttributeName())) return false;
+        if (!getAttributeType().equals(that.getAttributeType())) return false;
+        if (!objectType.equals(that.objectType)) return false;
+
+        return true;
+    }
+
+    public boolean canEqual(Object other) {
+        return other instanceof AbstractAttribute;
+    }
+
+    @Override
+    public int hashCode() {
+        return cachedHashCode;
+    }
+
+    int calcHashCode() {
+        int result = objectType.hashCode();
+        result = 31 * result + getAttributeType().hashCode();
+        result = 31 * result + getAttributeName().hashCode();
+        return result;
+    }
+
+
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/MultiValueAttribute.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/MultiValueAttribute.java
@@ -11,10 +11,7 @@ import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
-public abstract class MultiValueAttribute<O extends Entity, A> extends com.googlecode.cqengine.attribute
-        .MultiValueAttribute<EntityHandle<O>, A> implements Attribute<O, A> {
-
-    private Class<O> objectType;
+public abstract class MultiValueAttribute<O extends Entity, A> extends AbstractAttribute<O, A> {
 
     public MultiValueAttribute() {
         super();
@@ -25,14 +22,12 @@ public abstract class MultiValueAttribute<O extends Entity, A> extends com.googl
     }
 
     public MultiValueAttribute(Class<O> objectType, Class<EntityHandle<O>> handleType, Class<A> attributeType) {
-        super(handleType, attributeType);
-        this.objectType = objectType;
+        super(objectType, handleType, attributeType);
     }
 
-    public MultiValueAttribute(Class<O> objectType, Class<EntityHandle<O>> handleType, Class<A> attributeType, String
-            attributeName) {
-        super(handleType, attributeType, attributeName);
-        this.objectType = objectType;
+    public MultiValueAttribute(Class<O> objectType, Class<EntityHandle<O>> handleType, Class<A> attributeType,
+                               String attributeName) {
+        super(objectType, handleType, attributeType, attributeName);
     }
 
     @Override
@@ -42,8 +37,7 @@ public abstract class MultiValueAttribute<O extends Entity, A> extends com.googl
 
     public abstract Iterable<A> getValues(O object, QueryOptions queryOptions);
 
-    @Override public Class<O> getEffectiveObjectType() {
-        return objectType == null ? Attribute.readGenericObjectType(getClass(), getAttributeName()) : objectType;
+    @Override public boolean canEqual(Object other) {
+        return other instanceof MultiValueAttribute;
     }
-
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/SimpleAttribute.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/SimpleAttribute.java
@@ -13,6 +13,7 @@ import com.googlecode.cqengine.query.option.QueryOptions;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Collections;
 
 /**
  * An extension of {@link com.googlecode.cqengine.attribute.SimpleAttribute} that hides
@@ -21,11 +22,7 @@ import java.lang.reflect.Type;
  * @param <O>
  * @param <A>
  */
-public abstract class SimpleAttribute<O extends Entity, A>
-        extends com.googlecode.cqengine.attribute.SimpleAttribute<EntityHandle<O>, A>
-        implements Attribute<O, A> {
-
-    private Class<O> objectType;
+public abstract class SimpleAttribute<O extends Entity, A> extends AbstractAttribute<O, A> {
 
     public SimpleAttribute() {
         super();
@@ -36,24 +33,29 @@ public abstract class SimpleAttribute<O extends Entity, A>
     }
 
     public SimpleAttribute(Class<O> objectType, Class<EntityHandle<O>> handleType, Class<A> attributeType) {
-        super(handleType, attributeType);
-        this.objectType = objectType;
+        super(objectType, handleType, attributeType);
     }
 
-    public SimpleAttribute(Class<O> objectType, Class<EntityHandle<O>> handleType, Class<A> attributeType, String attributeName) {
-        super(handleType, attributeType, attributeName);
-        this.objectType = objectType;
+    public SimpleAttribute(Class<O> objectType, Class<EntityHandle<O>> handleType, Class<A> attributeType,
+                           String attributeName) {
+        super(objectType, handleType, attributeType, attributeName);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
+    public Iterable<A> getValues(EntityHandle<O> object, QueryOptions queryOptions) {
+        return Collections.singletonList(getValue(object, queryOptions));
+    }
+
     public A getValue(EntityHandle<O> object, QueryOptions queryOptions) {
         return getValue(object.get(), queryOptions);
     }
 
     public abstract A getValue(O object, QueryOptions queryOptions);
 
-    @Override public Class<O> getEffectiveObjectType() {
-        return objectType == null ? Attribute.readGenericObjectType(getClass(), getAttributeName()) : objectType;
+    @Override public boolean canEqual(Object other) {
+        return other instanceof SimpleAttribute;
     }
-
 }

--- a/eventsourcing-queries/src/main/java/com/eventsourcing/queries/IsLatestEntity.java
+++ b/eventsourcing-queries/src/main/java/com/eventsourcing/queries/IsLatestEntity.java
@@ -135,7 +135,7 @@ public class IsLatestEntity<O extends EntityHandle> extends SimpleQuery<O, Hybri
         List<Query<O>> conditions = StreamSupport.stream(values.spliterator(), false)
                                                  .map(v -> greaterThan(timestampAttribute, v))
                                                  .collect(Collectors.toList());
-        Query<O> timestampQuery = new Or<>(conditions);
+        Query<O> timestampQuery = conditions.size() == 1 ? conditions.get(0) : new Or<>(conditions);
         try (ResultSet<O> resultSet = collection.retrieve(and(
                 actualQuery,
                 timestampQuery))) {


### PR DESCRIPTION
`IllegalStateException: An equivalent index has already been added for attribute`

Solution: override equality testing and hashCode in Eventsourcing's
SimpleAttribute and MultiValueAttribute.

The problem was that the `objectType` passed to cqengine was always
`EntityHandle` which obviously has the same hash code for any entity.

By overriding these and checking the effective object type, cqengine
no longer thinks this index has already been added.