### PR TITLE
Problem: composing model collection queries is difficult

### DIFF
--- a/eventsourcing-queries/src/main/java/com/eventsourcing/queries/ModelCollectionQuery.java
+++ b/eventsourcing-queries/src/main/java/com/eventsourcing/queries/ModelCollectionQuery.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.queries;
+
+import com.eventsourcing.Model;
+import com.eventsourcing.Repository;
+
+import java.util.*;
+import java.util.stream.BaseStream;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A toolkit for composing model collections queries. An implementation of this interface
+ * can be passed to {@link #query(Repository, ModelCollectionQuery)} to retrieve a collection
+ * of matching model instances.
+ *
+ * Following logical operator functions can be used to compose a query:
+ *
+ * <ul>
+ *     <li>{@link LogicalOperators#or(Collection)}</li>
+ *     <li>{@link LogicalOperators#and(Collection)}</li>
+ * </ul>
+ *
+ * @param <T>
+ */
+public interface ModelCollectionQuery<T extends Model> {
+
+    Stream<T> getCollectionStream(Repository repository);
+
+    static <T extends Model> Collection<T> query(Repository repository, ModelCollectionQuery<T> query) {
+        try (Stream<T> collectionStream = query.getCollectionStream(repository)) {
+            return collectionStream.collect(Collectors.toList());
+        }
+    }
+
+
+    final class LogicalOperators {
+
+        public static <T extends Model> ModelCollectionQuery<T> or(Collection<ModelCollectionQuery<T>> queries) {
+            return new Or<>(queries);
+        }
+
+        public static <T extends Model> ModelCollectionQuery<T> or(ModelCollectionQuery<T>... queries) {
+            return new Or<>(queries);
+        }
+
+        public static class Or<T extends Model> implements ModelCollectionQuery<T> {
+
+            private final Collection<ModelCollectionQuery<T>> queries;
+
+            public Or(Collection<ModelCollectionQuery<T>> queries) {
+                this.queries = queries;
+            }
+
+            public Or(ModelCollectionQuery<T>... queries) {
+                this.queries = Arrays.asList(queries);
+            }
+
+            @Override public Stream<T> getCollectionStream(Repository repository) {
+                Stream<T> stream = Stream.empty();
+                List<Stream<T>> streams = new ArrayList<>();
+                Set<UUID> seen = new HashSet<>();
+                for (ModelCollectionQuery<T> query : queries) {
+                    Stream<T> queryStream = query.getCollectionStream(repository)
+                                                 .filter(m -> !seen.contains(m.getId()))
+                                                 .map(m -> {
+                                                     seen.add(m.getId());
+                                                     return m;
+                                                 });
+
+                    streams.add(queryStream);
+                    stream = Stream.concat(stream, queryStream);
+                }
+                return stream.onClose(() -> {
+                    streams.forEach(BaseStream::close);
+                });
+            }
+        }
+
+        public static <T extends Model> ModelCollectionQuery<T> and(Collection<ModelCollectionQuery<T>> queries) {
+            return new And<>(queries);
+        }
+
+        public static <T extends Model> ModelCollectionQuery<T> and(ModelCollectionQuery<T>... queries) {
+            return new And<>(queries);
+        }
+
+        public static class And<T extends Model> implements ModelCollectionQuery<T> {
+
+            private final Collection<ModelCollectionQuery<T>> queries;
+
+            public And(Collection<ModelCollectionQuery<T>> queries) {
+                this.queries = queries;
+            }
+
+            public And(ModelCollectionQuery<T>... queries) {
+                this.queries = Arrays.asList(queries);
+            }
+
+            @Override public Stream<T> getCollectionStream(Repository repository) {
+                Iterator<ModelCollectionQuery<T>> iterator = queries.iterator();
+                if (iterator.hasNext()) {
+                    ModelCollectionQuery<T> first = iterator.next();
+                    Stream<T> firstStream = first.getCollectionStream(repository);
+                    List<T> realizedStream = firstStream.collect(Collectors.toList());
+                    Set<UUID> set = realizedStream.stream()
+                                                  .map(Model::getId).collect(Collectors.toSet());
+                    Set<UUID> seen = new HashSet<>();
+                    firstStream.close();
+                    List<ModelCollectionQuery<T>> allQueries = new ArrayList<>();
+                    iterator.forEachRemaining(allQueries::add);
+
+                    Stream<T> stream = Stream.empty();
+                    List<Stream<T>> streams = new ArrayList<>();
+                    for (ModelCollectionQuery<T> query : allQueries) {
+                        Stream<T> queryStream =
+                                query.getCollectionStream(repository)
+                                     .filter(m -> set.contains(m.getId()) && !seen.contains(m.getId()))
+                                     .map(m -> {
+                                         seen.add(m.getId());
+                                         return m;
+                                     });
+                        streams.add(queryStream);
+                        stream = Stream.concat(stream, queryStream);
+                    }
+                    stream = Stream.concat(realizedStream.stream().filter(m -> seen.contains(m.getId())),
+                                           stream);
+                    return stream.onClose(() -> streams.forEach(BaseStream::close));
+
+                } else {
+                    return Stream.empty();
+                }
+            }
+        }
+    }
+}

--- a/eventsourcing-queries/src/test/java/com/eventsourcing/queries/ModelCollectionQueryTest.java
+++ b/eventsourcing-queries/src/test/java/com/eventsourcing/queries/ModelCollectionQueryTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.queries;
+
+import com.eventsourcing.Model;
+import com.eventsourcing.Repository;
+import com.google.common.collect.Iterables;
+import lombok.Value;
+import lombok.experimental.Accessors;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static com.eventsourcing.queries.ModelCollectionQuery.LogicalOperators.and;
+import static com.eventsourcing.queries.ModelCollectionQuery.LogicalOperators.or;
+import static org.testng.Assert.*;
+
+public class ModelCollectionQueryTest {
+
+    @Value
+    static class MyModel implements Model {
+        private Repository repository;
+        private UUID id;
+        @Accessors(fluent = true)
+        private String name;
+    }
+
+    static class MyQuery1 implements ModelCollectionQuery<MyModel> {
+
+        @Override public Stream<MyModel> getCollectionStream(Repository repository) {
+            return Stream.of(new MyModel(repository, UUID.nameUUIDFromBytes("test1".getBytes()), "test1"),
+                             new MyModel(repository, UUID.nameUUIDFromBytes("test1_1".getBytes()), "test1_1"));
+        }
+    }
+
+    static class MyQuery2 implements ModelCollectionQuery<MyModel> {
+
+        @Override public Stream<MyModel> getCollectionStream(Repository repository) {
+            return Stream.of(new MyModel(repository, UUID.nameUUIDFromBytes("test2".getBytes()), "test2"),
+                             new MyModel(repository, UUID.nameUUIDFromBytes("test1_1".getBytes()), "test1_1"));
+        }
+    }
+
+    @Test
+    public void query() {
+        Collection<MyModel> collection = ModelCollectionQuery.query(null, new MyQuery1());
+        Iterables.any(collection, m -> m.name().contains("test1"));
+        Iterables.any(collection, m -> m.name().contains("test1_1"));
+    }
+
+    @Test
+    public void queryAnd() {
+        Collection<MyModel> collection = ModelCollectionQuery.query(null, and(new MyQuery1(), new MyQuery2()));
+        assertEquals(collection.size(), 1);
+        Iterables.any(collection, m -> m.name().contains("test1_1"));
+    }
+
+    @Test
+    public void queryOr() {
+        Collection<MyModel> collection = ModelCollectionQuery.query(null, or(new MyQuery1(), new MyQuery2()));
+        assertEquals(collection.size(), 3);
+        Iterables.any(collection, m -> m.name().contains("test1"));
+        Iterables.any(collection, m -> m.name().contains("test1_1"));
+        Iterables.any(collection, m -> m.name().contains("test2"));
+    }
+
+}


### PR DESCRIPTION
Having one-off model collection query methods is good for simple
applications, but when combinations of those queries are required,
compisability is often sought.

Solution: introduce ModelCollectionQuery interface to compose
the queries.