### PR TITLE
Problem: having to declare Repository arg in StandardCommands#events

### DIFF
--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DeletedProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DeletedProtocolTest.java
@@ -50,7 +50,7 @@ public class DeletedProtocolTest extends RepositoryUsingTest {
         }
 
         @Override
-        public EventStream<Void> events(Repository repository) throws Exception {
+        public EventStream<Void> events() throws Exception {
             Deleted reference = Deleted.builder().reference(id).build();
             eventId = reference.uuid();
             return EventStream.of(reference);
@@ -80,7 +80,7 @@ public class DeletedProtocolTest extends RepositoryUsingTest {
 
 
         @Override
-        public EventStream<Void> events(Repository repository) throws Exception {
+        public EventStream<Void> events() throws Exception {
             return EventStream.of(Undeleted.builder().deleted(id).build());
         }
 

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DescriptionProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DescriptionProtocolTest.java
@@ -51,7 +51,7 @@ public class DescriptionProtocolTest extends RepositoryUsingTest {
         }
 
         @Override
-        public EventStream<Void> events(Repository repository) throws Exception {
+        public EventStream<Void> events() throws Exception {
             return EventStream.of(DescriptionChanged.builder()
                     .reference(id)
                     .description(description)

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/NameProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/NameProtocolTest.java
@@ -51,7 +51,7 @@ public class NameProtocolTest extends RepositoryUsingTest {
         }
 
         @Override
-        public EventStream<Void> events(Repository repository) throws Exception {
+        public EventStream<Void> events() throws Exception {
             return EventStream.of(NameChanged.builder().reference(id).name(name).timestamp(timestamp()).build());
         }
 

--- a/eventsourcing-core/src/main/java/com/eventsourcing/StandardCommand.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/StandardCommand.java
@@ -24,6 +24,18 @@ public abstract class StandardCommand<S, R> extends StandardEntity<Command<S, R>
     /**
      * Returns a stream of events that should be recorded. By default, an empty stream returned.
      *
+     * @return stream of events
+     * @throws Exception if the command is to be rejected, an exception has to be thrown. In this case, no events will
+     *                   be recorded
+     */
+
+    public EventStream<S> events() throws Exception {
+        return EventStream.empty();
+    }
+
+    /**
+     * Returns a stream of events that should be recorded. By default, calls {@link #events()}
+     *
      * @param repository Configured repository
      * @return stream of events
      * @throws Exception if the command is to be rejected, an exception has to be thrown. In this case, no events will
@@ -31,7 +43,7 @@ public abstract class StandardCommand<S, R> extends StandardEntity<Command<S, R>
      */
 
     public EventStream<S> events(Repository repository) throws Exception {
-        return EventStream.empty();
+        return events();
     }
 
     @Override public EventStream<S> events(Repository repository, LockProvider lockProvider) throws

--- a/eventsourcing-core/src/test/java/com/eventsourcing/StandardCommandTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/StandardCommandTest.java
@@ -16,9 +16,15 @@ import static org.testng.Assert.*;
 
 public class StandardCommandTest {
 
+    public static class SomeEvent extends StandardEvent {}
+
     @Value
     public static class SomeCommand extends StandardCommand<Void, Void> {
         String a;
+
+        @Override public EventStream<Void> events() throws Exception {
+            return EventStream.of(new SomeEvent());
+        }
     }
 
     @Test
@@ -28,6 +34,13 @@ public class StandardCommandTest {
         assertEquals(layout.getProperties().size(), 2);
         assertNotNull(layout.getProperty("a"));
         assertNotNull(layout.getProperty("timestamp"));
+    }
+
+    @Test
+    @SneakyThrows
+    public void passthrough() {
+        EventStream<Void> eventStream = new SomeCommand("a").events(null, null);
+        assertTrue(eventStream.getStream().anyMatch(e -> e instanceof SomeEvent));
     }
 
 }

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexEngineTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexEngineTest.java
@@ -114,7 +114,7 @@ public abstract class IndexEngineTest<T extends IndexEngine> {
         }
 
         @Override
-        public EventStream<Void> events(Repository repository) {
+        public EventStream<Void> events() {
             return EventStream.of(TestEvent.builder().string(string).build());
         }
     }

--- a/eventsourcing-migrations/src/test/java/com/eventsourcing/migrations/LayoutMigrationTest.java
+++ b/eventsourcing-migrations/src/test/java/com/eventsourcing/migrations/LayoutMigrationTest.java
@@ -40,7 +40,7 @@ public class LayoutMigrationTest extends RepositoryTest {
             super(timestamp);
         }
 
-        @Override public EventStream<Void> events(Repository repository) throws Exception {
+        @Override public EventStream<Void> events() throws Exception {
             return EventStream.of(TestEvent1.builder().x(0).build());
         }
     }

--- a/eventsourcing-postgresql/src/test/java/com/eventsourcing/postgresql/PostgreSQLJournalTest.java
+++ b/eventsourcing-postgresql/src/test/java/com/eventsourcing/postgresql/PostgreSQLJournalTest.java
@@ -224,7 +224,7 @@ public class PostgreSQLJournalTest extends JournalTest<PostgreSQLJournal> {
             this.t = t;
         }
 
-        @Override public EventStream<SerializationEvent> events(Repository repository) throws Exception {
+        @Override public EventStream<SerializationEvent> events() throws Exception {
             SerializationEvent.SerializationEventBuilder builder = SerializationEvent.builder();
             if (t != null) {
                 builder.test(t);

--- a/eventsourcing-queries/src/test/java/com/eventsourcing/queries/IsLatestEntityTest.java
+++ b/eventsourcing-queries/src/test/java/com/eventsourcing/queries/IsLatestEntityTest.java
@@ -70,7 +70,7 @@ public class IsLatestEntityTest extends RepositoryUsingTest {
         private String test;
         private UUID reference;
 
-        @Override public EventStream<Void> events(Repository repository) throws Exception {
+        @Override public EventStream<Void> events() throws Exception {
             TestEvent event = new TestEvent(test, reference);
             return EventStream.of(event);
         }

--- a/eventsourcing-queries/src/test/java/com/eventsourcing/queries/ModelQueriesTest.java
+++ b/eventsourcing-queries/src/test/java/com/eventsourcing/queries/ModelQueriesTest.java
@@ -37,7 +37,7 @@ public class ModelQueriesTest extends RepositoryUsingTest {
     }
 
     public static class TestCommand extends StandardCommand<TestEvent, UUID> {
-        @Override public EventStream<TestEvent> events(Repository repository) throws Exception {
+        @Override public EventStream<TestEvent> events() throws Exception {
             TestEvent event = new TestEvent();
             return EventStream.ofWithState(event, event);
         }

--- a/eventsourcing-repository/src/main/java/boguspackage/BogusCommand.java
+++ b/eventsourcing-repository/src/main/java/boguspackage/BogusCommand.java
@@ -21,7 +21,7 @@ public class BogusCommand extends StandardCommand<Void, String> {
     }
 
     @Override
-    public EventStream<Void> events(Repository repository) throws Exception {
+    public EventStream<Void> events() throws Exception {
         return EventStream.of(BogusEvent.builder().build());
     }
 

--- a/eventsourcing-repository/src/test/java/com/eventsourcing/repository/JournalTest.java
+++ b/eventsourcing-repository/src/test/java/com/eventsourcing/repository/JournalTest.java
@@ -113,7 +113,7 @@ public abstract class JournalTest<T extends Journal> {
         }
 
         @Override
-        public EventStream<Void> events(Repository repository) throws Exception {
+        public EventStream<Void> events() throws Exception {
             return EventStream.of(Stream.generate(() -> {
                 throw new IllegalStateException();
             }));

--- a/eventsourcing-repository/src/test/java/com/eventsourcing/repository/RepositoryTest.java
+++ b/eventsourcing-repository/src/test/java/com/eventsourcing/repository/RepositoryTest.java
@@ -131,7 +131,7 @@ public abstract class RepositoryTest<T extends Repository> {
 
 
         @Override
-        public EventStream<Void> events(Repository repository) {
+        public EventStream<Void> events() {
             return EventStream.of(TestEvent.builder().string(value).build());
         }
 
@@ -263,7 +263,7 @@ public abstract class RepositoryTest<T extends Repository> {
 
 
         @Override
-        public EventStream<Void> events(Repository repository) {
+        public EventStream<Void> events() {
             return EventStream.of(new Event[]{
                                   TestEvent.builder().string("test").timestamp(eventTimestamp).build(),
                                   TestEvent.builder().string("followup").build()});
@@ -384,7 +384,7 @@ public abstract class RepositoryTest<T extends Repository> {
         }
 
         @Override
-        public EventStream<Void> events(Repository repository) {
+        public EventStream<Void> events() {
             throw new IllegalStateException();
         }
     }
@@ -441,7 +441,7 @@ public abstract class RepositoryTest<T extends Repository> {
 
 
         @Override
-        public EventStream<Void> events(Repository repository) {
+        public EventStream<Void> events() {
             return EventStream.of(Stream.concat(Stream.of(
                     TestEvent.builder().string("test").build().uuid(eventUUID)),
                                  Stream.generate(() -> {
@@ -553,7 +553,7 @@ public abstract class RepositoryTest<T extends Repository> {
         }
 
         @Override
-        public EventStream<Void> events(Repository repository) {
+        public EventStream<Void> events() {
             return EventStream.of(TestOptionalEvent.builder().optional(optional).build());
         }
 

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AddProductToOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AddProductToOrder.java
@@ -39,7 +39,7 @@ public class AddProductToOrder extends StandardCommand<ProductAddedToOrder, Orde
     }
 
     @Override
-    public EventStream<ProductAddedToOrder> events(Repository repository) throws Exception {
+    public EventStream<ProductAddedToOrder> events() throws Exception {
         ProductAddedToOrder addedToOrder = ProductAddedToOrder.builder()
                 .orderId(orderId).productId(productId).quantity(quantity).build();
         return EventStream.ofWithState(addedToOrder, addedToOrder);

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AdjustItemQuantity.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/AdjustItemQuantity.java
@@ -33,7 +33,7 @@ public class AdjustItemQuantity extends StandardCommand<Void, Void> {
     }
 
     @Override
-    public EventStream<Void> events(Repository repository) throws Exception {
+    public EventStream<Void> events() throws Exception {
         return EventStream.of(ItemQuantityAdjusted.builder().itemId(itemId).quantity(quantity).build());
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CancelOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CancelOrder.java
@@ -29,7 +29,7 @@ public class CancelOrder extends StandardCommand<Void, Void> {
     }
 
     @Override
-    public EventStream<Void> events(Repository repository) throws Exception {
+    public EventStream<Void> events() throws Exception {
         return EventStream.of(OrderCancelled.builder().id(id).build());
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/ChangePrice.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/ChangePrice.java
@@ -33,7 +33,7 @@ public class ChangePrice extends StandardCommand<Void, BigDecimal> {
     }
 
     @Override
-    public EventStream<Void> events(Repository repository) throws Exception {
+    public EventStream<Void> events() throws Exception {
         return EventStream.of(PriceChanged.builder().id(id).price(price).build());
     }
 

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateOrder.java
@@ -20,7 +20,7 @@ public class CreateOrder extends StandardCommand<OrderCreated, Order> {
     public CreateOrder() {}
 
     @Override
-    public EventStream<OrderCreated> events(Repository repository) throws Exception {
+    public EventStream<OrderCreated> events() throws Exception {
         OrderCreated orderCreated = OrderCreated.builder().build();
         return EventStream.ofWithState(orderCreated, orderCreated);
     }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateProduct.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/CreateProduct.java
@@ -37,7 +37,7 @@ public class CreateProduct extends StandardCommand<ProductCreated, Product> {
     }
 
     @Override
-    public EventStream<ProductCreated> events(Repository repository) throws Exception {
+    public EventStream<ProductCreated> events() throws Exception {
         ProductCreated productCreated = ProductCreated.builder().build();
         NameChanged nameChanged = NameChanged.builder().id(productCreated.uuid()).name(name).build();
         PriceChanged priceChanged = PriceChanged.builder().id(productCreated.uuid()).price(price).build();

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/RemoveItemFromOrder.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/RemoveItemFromOrder.java
@@ -30,7 +30,7 @@ public class RemoveItemFromOrder extends StandardCommand<Void, Void> {
     }
 
     @Override
-    public EventStream<Void> events(Repository repository) throws Exception {
+    public EventStream<Void> events() throws Exception {
         return EventStream.of(ItemRemovedFromOrder.builder().itemId(itemId).build());
     }
 }

--- a/examples/order/src/main/java/com/eventsourcing/examples/order/commands/Rename.java
+++ b/examples/order/src/main/java/com/eventsourcing/examples/order/commands/Rename.java
@@ -32,7 +32,7 @@ public class Rename extends StandardCommand<Void, String> {
     }
 
     @Override
-    public EventStream<Void> events(Repository repository) throws Exception {
+    public EventStream<Void> events() throws Exception {
         return EventStream.of(NameChanged.builder().id(id).name(name).build());
     }
 

--- a/src/jmh/java/com/eventsourcing/jmh/TestCommand.java
+++ b/src/jmh/java/com/eventsourcing/jmh/TestCommand.java
@@ -20,7 +20,7 @@ public class TestCommand extends StandardCommand<Void, String> {
     }
 
     @Override
-    public EventStream<Void> events(Repository repository) {
+    public EventStream<Void> events() {
         return EventStream.of(TestEvent.builder().string("test").build());
     }
 


### PR DESCRIPTION
Often times, the repository is not needed to produce events

Solution: provide a no-arguments method that would be called if
no other methods are overriden.