### PR TITLE
Problem: maintaining an explicit list of modules to upload to bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - ./gradlew publishToMavenLocal
   - cd examples/order && ./gradlew check
 after_success:
-  - cd ../.. && ./gradlew -Psnapshot=true :eventsourcing-core:bintrayUpload :eventsourcing-layout:bintrayUpload :eventsourcing-hlc:bintrayUpload :eventsourcing-h2:bintrayUpload :eventsourcing-cep:bintrayUpload :eventsourcing-migrations:bintrayUpload :eventsourcing-postgresql:bintrayUpload :eventsourcing-inmem:bintrayUpload :eventsourcing-repository:bintrayUpload
+  - cd ../.. && ./gradlew -Psnapshot=true bintrayUpload
 env:
   global:
     - PGPORT=5433

--- a/build.gradle
+++ b/build.gradle
@@ -209,10 +209,7 @@ dependencies {
 
 }
 
-afterReleaseBuild.dependsOn project(':eventsourcing-layout').tasks.findByName("bintrayUpload")
-afterReleaseBuild.dependsOn project(':eventsourcing-hlc').tasks.findByName("bintrayUpload")
-afterReleaseBuild.dependsOn project(':eventsourcing-core').tasks.findByName("bintrayUpload")
-afterReleaseBuild.dependsOn project(':eventsourcing-queries').tasks.findByName("bintrayUpload")
-afterReleaseBuild.dependsOn project(':eventsourcing-h2').tasks.findByName("bintrayUpload")
-afterReleaseBuild.dependsOn project(':eventsourcing-cep').tasks.findByName("bintrayUpload")
+subprojects.forEach {
+    afterReleaseBuild.dependsOn it.tasks.findByName("bintrayUpload")
+}
 


### PR DESCRIPTION
When new module is added, it is sometimes hard to remember to add it
to all the necessary places in the build system

Solution: simply rely on Gradle's knowledge of subprojects.