### PR TITLE
Problem: exception when null values are passed in Layout#instantiate

### DIFF
--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/Layout.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/Layout.java
@@ -394,7 +394,7 @@ public class Layout<T> {
     private Optional<Object> findProperty(Map<Property<T>, Object> properties, String name) {
         for (Map.Entry<Property<T>, Object> entry : properties.entrySet()) {
             if (entry.getKey().getName().contentEquals(name)) {
-                return Optional.of(entry.getValue());
+                return Optional.ofNullable(entry.getValue());
             }
         }
         return Optional.empty();

--- a/eventsourcing-layout/src/test/java/com/eventsourcing/layout/LayoutTest.java
+++ b/eventsourcing-layout/src/test/java/com/eventsourcing/layout/LayoutTest.java
@@ -346,6 +346,16 @@ public class LayoutTest {
         assertFalse(instance.isB());
     }
 
+    @Test
+    @SneakyThrows
+    public void nullValueInConstructorArgs() {
+        Layout<Initializer> layout = Layout.forClass(Initializer.class);
+        HashMap<Property<Initializer>, Object> properties = new HashMap<>();
+        properties.put(layout.getProperty("a"), null);
+        Initializer instance = layout.instantiate(properties);
+        assertEquals(instance.getA(), "");
+    }
+
     public static class Base0Class {
         @Getter @Setter
         private String a;


### PR DESCRIPTION
Solution: treat null values as if they weren't defined, allowing
to use the default type values.