### PR TITLE
Problem: failure to start StandardRepository with duplicate indices

### DIFF
--- a/eventsourcing-repository/src/main/java/com/eventsourcing/repository/StandardRepository.java
+++ b/eventsourcing-repository/src/main/java/com/eventsourcing/repository/StandardRepository.java
@@ -132,7 +132,15 @@ public class StandardRepository extends AbstractService implements Repository, R
             if (!indicesConfiguredFor.contains(klass.getName())) {
                 Iterable<Index> indices = indexEngine.getIndices(klass);
                 for (Index i : indices) {
-                    indexEngine.getIndexedCollection(klass).addIndex(i);
+                    try {
+                        indexEngine.getIndexedCollection(klass).addIndex(i);
+                    } catch (IllegalStateException e) {
+                        if (e.getMessage().contains("has already been added")) {
+                            // ignore the re-addition of the index
+                        } else {
+                            throw e;
+                        }
+                    }
                 }
                 indicesConfiguredFor.add(klass.getName());
             }


### PR DESCRIPTION
The problem occurs in OSGi environments when IndexEngine can (supposedly)
get re-wired to a new StandardRepository instance. If IndexEngine has the
index added, when StandardRepository is wired to events/commands again,
it will attempt to add those indices again.

Related issue: https://github.com/npgall/cqengine/issues/79

Solution: check if it was an attempt to add an equivalent index, and if it was,
swallow the exception.

This is not a perfect solution, but if https://github.com/npgall/cqengine/issues/79 gets
solved, it can be improved.