### PR TITLE
Problem: StandardRepository initialization doesn't look pretty

### DIFF
--- a/docs/getting_started/publishing.md
+++ b/docs/getting_started/publishing.md
@@ -4,13 +4,10 @@ Repository is an entry point to most of end-user ES4J functionality.
 It puts all components (journalling, indexing, querying) together and allows to publish commands.
 
 ```java
-Repository repository = new StandardRepository();
-
-Journal journal = new MemoryJournal();
-repository.setJournal(journal);
-
-IndexEngine indexEngine = new MemoryIndexEngine();
-repository.setIndexEngine(indexEngine);
+Repository repository = StandardRepository.builder()
+                        .journal(new MemoryJournal())
+                        .indexEngine(new MemoryIndexEngine()).
+                        build();
 
 // ES4J should find commands and events in this
 // hierarchy of packages:

--- a/eventsourcing-queries/src/test/java/com/eventsourcing/queries/RepositoryUsingTest.java
+++ b/eventsourcing-queries/src/test/java/com/eventsourcing/queries/RepositoryUsingTest.java
@@ -32,13 +32,10 @@ public class RepositoryUsingTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
-        timeProvider = new NTPServerTimeProvider(new String[]{"localhost"});
-        repository = new StandardRepository();
-        repository.setPhysicalTimeProvider(timeProvider);
-        repository.setJournal(new MemoryJournal());
-        repository.setIndexEngine(new MemoryIndexEngine());
-        lockProvider = new LocalLockProvider();
-        repository.setLockProvider(lockProvider);
+        repository =
+        StandardRepository.builder()
+                          .journal(new MemoryJournal())
+                          .indexEngine(new MemoryIndexEngine()).build();
         repository.startAsync().awaitRunning();
         // Add commands/events after the startup, to simulate production better
         repository.addCommandSetProvider(new PackageCommandSetProvider(packages));

--- a/eventsourcing-repository/src/main/java/com/eventsourcing/repository/StandardRepository.java
+++ b/eventsourcing-repository/src/main/java/com/eventsourcing/repository/StandardRepository.java
@@ -22,6 +22,7 @@ import com.google.common.util.concurrent.AbstractService;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;
 import com.googlecode.cqengine.index.Index;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +43,17 @@ public class StandardRepository extends AbstractService implements Repository, R
     public StandardRepository() {
         setPhysicalTimeProvider(new NTPServerTimeProvider(new String[]{"localhost"}));
         setLockProvider(new LocalLockProvider());
+    }
+
+    @Builder
+    @SneakyThrows
+    public StandardRepository(Journal journal, PhysicalTimeProvider physicalTimeProvider,
+                              IndexEngine indexEngine, LockProvider lockProvider) {
+        setPhysicalTimeProvider(physicalTimeProvider == null ?
+                                        new NTPServerTimeProvider(new String[]{"localhost"}) : physicalTimeProvider);
+        setLockProvider(lockProvider == null ? new LocalLockProvider() : lockProvider);
+        setJournal(journal);
+        setIndexEngine(indexEngine);
     }
 
     @Getter


### PR DESCRIPTION
Solution: implement StandardRepository.builder() to prettify
its initialization.