### PR TITLE
Problem: index definition syntax is slightly verbose

### DIFF
--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Deleted.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Deleted.java
@@ -7,6 +7,7 @@
  */
 package com.eventsourcing.cep.events;
 
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Index;
@@ -37,12 +38,12 @@ public class Deleted extends StandardEvent {
     final UUID reference;
 
     @Index
-    public static SimpleIndex<Deleted, UUID> ID = (object, queryOptions) -> object.uuid();
+    public static SimpleIndex<Deleted, UUID> ID = StandardEntity::uuid;
 
-    public static SimpleIndex<Deleted, UUID> REFERENCE_ID = (object, queryOptions) -> object.reference();
+    public static SimpleIndex<Deleted, UUID> REFERENCE_ID = Deleted::reference;
 
     @Index({EQ, LT, GT})
-    public static SimpleIndex<Deleted, HybridTimestamp> TIMESTAMP = (object, queryOptions) -> object.timestamp();
+    public static SimpleIndex<Deleted, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
 
     @LayoutConstructor
     public Deleted(UUID reference) {

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/DescriptionChanged.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/DescriptionChanged.java
@@ -7,6 +7,7 @@
  */
 package com.eventsourcing.cep.events;
 
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Index;
@@ -48,11 +49,10 @@ public class DescriptionChanged extends StandardEvent {
         this.description = description;
     }
 
-    public static SimpleIndex<DescriptionChanged, UUID> REFERENCE_ID = (object, queryOptions) -> object.reference();
+    public static SimpleIndex<DescriptionChanged, UUID> REFERENCE_ID = DescriptionChanged::reference;
 
-    public static SimpleIndex<DescriptionChanged, String> DESCRIPTION = (object, queryOptions) -> object.description();
+    public static SimpleIndex<DescriptionChanged, String> DESCRIPTION = DescriptionChanged::description;
 
     @Index({LT, GT, EQ})
-    public static SimpleIndex<DescriptionChanged, HybridTimestamp> TIMESTAMP = (object, queryOptions) -> object
-            .timestamp();
+    public static SimpleIndex<DescriptionChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
 }

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/NameChanged.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/NameChanged.java
@@ -7,6 +7,7 @@
  */
 package com.eventsourcing.cep.events;
 
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Index;
@@ -48,10 +49,10 @@ public class NameChanged extends StandardEvent {
         this.name = name;
     }
 
-    public static SimpleIndex<NameChanged, UUID> REFERENCE_ID = (object, queryOptions) -> object.reference();
+    public static SimpleIndex<NameChanged, UUID> REFERENCE_ID = NameChanged::reference;
 
-    public static SimpleIndex<NameChanged, String> NAME = (object, queryOptions) -> object.name();
+    public static SimpleIndex<NameChanged, String> NAME = NameChanged::name;
 
     @Index({LT, GT, EQ})
-    public static SimpleIndex<NameChanged, HybridTimestamp> TIMESTAMP = (object, queryOptions) -> object.timestamp();
+    public static SimpleIndex<NameChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
 }

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Undeleted.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Undeleted.java
@@ -7,6 +7,7 @@
  */
 package com.eventsourcing.cep.events;
 
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Index;
@@ -35,10 +36,10 @@ public class Undeleted extends StandardEvent {
     @Getter
     final UUID deleted;
 
-    public static SimpleIndex<Undeleted, UUID> DELETED_ID = (object, queryOptions) -> object.deleted();
+    public static SimpleIndex<Undeleted, UUID> DELETED_ID = Undeleted::deleted;
 
     @Index({EQ, LT, GT})
-    public static SimpleIndex<Undeleted, HybridTimestamp> TIMESTAMP = (object, queryOptions) -> object.timestamp();
+    public static SimpleIndex<Undeleted, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
 
     @LayoutConstructor
     public Undeleted(UUID deleted) {

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DeletedProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DeletedProtocolTest.java
@@ -43,7 +43,7 @@ public class DeletedProtocolTest extends RepositoryUsingTest {
         }
     }
     public static class Created extends StandardEvent {
-        public static SimpleIndex<Created, UUID> ID = (object, queryOptions) -> object.uuid();
+        public static SimpleIndex<Created, UUID> ID = StandardEntity::uuid;
     }
 
     @Accessors(fluent = true)

--- a/eventsourcing-core/src/main/java/com/eventsourcing/events/CommandTerminatedExceptionally.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/events/CommandTerminatedExceptionally.java
@@ -7,6 +7,7 @@
  */
 package com.eventsourcing.events;
 
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.index.SimpleIndex;
 import com.eventsourcing.layout.LayoutName;
@@ -18,5 +19,5 @@ import java.util.UUID;
 @LayoutName("rfc.eventsourcing.com/spec:9/RIG/#CommandTerminatedExceptionally")
 public class CommandTerminatedExceptionally extends StandardEvent {
 
-    public static SimpleIndex<CommandTerminatedExceptionally, UUID> ID = (object, queryOptions) -> object.uuid();
+    public static SimpleIndex<CommandTerminatedExceptionally, UUID> ID = StandardEntity::uuid;
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/events/EventCausalityEstablished.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/events/EventCausalityEstablished.java
@@ -35,7 +35,7 @@ public class EventCausalityEstablished extends StandardEvent {
         this.command = command;
     }
 
-    public static SimpleIndex<EventCausalityEstablished, UUID> EVENT = (object, queryOptions) -> object.event();
+    public static SimpleIndex<EventCausalityEstablished, UUID> EVENT = EventCausalityEstablished::event;
 
-    public static SimpleIndex<EventCausalityEstablished, UUID> COMMAND = (object, queryOptions) -> object.command();
+    public static SimpleIndex<EventCausalityEstablished, UUID> COMMAND = EventCausalityEstablished::command;
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/events/JavaExceptionOccurred.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/events/JavaExceptionOccurred.java
@@ -7,6 +7,7 @@
  */
 package com.eventsourcing.events;
 
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.index.SimpleIndex;
 import lombok.Getter;
@@ -69,6 +70,6 @@ public class JavaExceptionOccurred extends StandardEvent {
                 map(StackTraceElement::new).collect(Collectors.toList());
     }
 
-    public static SimpleIndex<JavaExceptionOccurred, UUID> ID = (object, queryOptions) -> object.uuid();
+    public static SimpleIndex<JavaExceptionOccurred, UUID> ID = StandardEntity::uuid;
 
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/IndexEngine.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/IndexEngine.java
@@ -140,6 +140,10 @@ public interface IndexEngine extends Service {
                                 return attribute;
                             }
 
+                            @Override public Object getValue(Entity object) {
+                                return ((SimpleIndex) index).getValue(object);
+                            }
+
                             @Override public Object getValue(Entity object, QueryOptions queryOptions) {
                                 return ((SimpleIndex) index).getValue(object, queryOptions);
                             }
@@ -149,6 +153,10 @@ public interface IndexEngine extends Service {
                         field.set(null, new MultiValueIndex() {
                             @Override public Attribute getAttribute() {
                                 return attribute;
+                            }
+
+                            @Override public Iterable getValues(Entity object) {
+                                return ((MultiValueIndex)index).getValues(object);
                             }
 
                             @Override public Iterable getValues(Entity object, QueryOptions queryOptions) {

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/MultiValueIndex.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/MultiValueIndex.java
@@ -10,14 +10,59 @@ package com.eventsourcing.index;
 import com.eventsourcing.Entity;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
+import java.util.function.BiFunction;
+
 /**
- * Designates a multiple values index
+ * Designates a multiple values index using a functional interface
+ *
+ * Typically, a definition will look like this:
+ *
+ * <pre>
+ * <code>
+ * public static MultiValueIndex&lt;TestEvent, UUID&gt; REFERENCE_ID = (object) -&gt; ...;
+ * </code>
+ * </pre>
+ *
+ * However, there are cases when accessing {@link QueryOptions} is necessary. This can be achieved
+ * using {@link MultiValueIndex#withQueryOptions(BiFunction)}:
+ *
+ * <pre>
+ * <code>
+ * public static MultiValueIndex&lt;TestEvent, UUID&gt; REFERENCE_ID =
+ *    MultiValueIndex.withQueryOptions((object, queryOptions) -&gt; ...);
+ * </code>
+ * </pre>
+ *
  * @param <O> entity type
  * @param <A> attribute type
  */
 @FunctionalInterface
 public interface MultiValueIndex<O extends Entity, A> extends EntityIndex<O, A> {
-    Iterable<A> getValues(O object, QueryOptions queryOptions);
+    default Iterable<A> getValues(O object, QueryOptions queryOptions) {
+        return getValues(object);
+    }
+
+    Iterable<A> getValues(O object);
+
+    /**
+     * Creates a MultiValueIndex with a function that can access {@link QueryOptions}
+     * @param function
+     * @param <O>
+     * @param <A>
+     * @return
+     */
+    static <O extends Entity, A> MultiValueIndex<O, A>
+        withQueryOptions(BiFunction<O, QueryOptions, Iterable<A>> function) {
+        return new MultiValueIndex<O, A>() {
+            @Override public Iterable<A> getValues(O object, QueryOptions queryOptions) {
+                return function.apply(object, queryOptions);
+            }
+
+            @Override public Iterable<A> getValues(O object) {
+                return function.apply(object, EntityQueryFactory.noQueryOptions());
+            }
+        };
+    }
 
     default Attribute<O, A> getAttribute() {
         throw new IllegalStateException("Index " + this + " hasn't been initialized yet");

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexEngineTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexEngineTest.java
@@ -86,10 +86,10 @@ public abstract class IndexEngineTest<T extends IndexEngine> {
         @Getter @Accessors(chain = true)
         private final String anotherString;
 
-        public static SimpleIndex<TestEvent, String> ANOTHER_ATTR = (object, queryOptions) -> object.getAnotherString();
+        public static SimpleIndex<TestEvent, String> ANOTHER_ATTR = TestEvent::getAnotherString;
 
         @Index
-        public static SimpleIndex<TestEvent, String> ATTR = (object, queryOptions) -> object.getString();
+        public static SimpleIndex<TestEvent, String> ATTR = TestEvent::getString;
     }
 
     @Accessors(fluent = true)

--- a/eventsourcing-kotlin/src/test/kotlin/EntityTest.kt
+++ b/eventsourcing-kotlin/src/test/kotlin/EntityTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
 @UseClassAnalyzer(KotlinClassAnalyzer::class)
 class TestEntity(val x: String) : StandardEvent() {
     companion object {
-        @JvmField var X = SimpleIndex { o: TestEntity, queryOptions -> o.x }
+        @JvmField var X = SimpleIndex { o: TestEntity -> o.x }
     }
 }
 

--- a/eventsourcing-migrations/src/main/java/com/eventsourcing/migrations/events/EntityLayoutIntroduced.java
+++ b/eventsourcing-migrations/src/main/java/com/eventsourcing/migrations/events/EntityLayoutIntroduced.java
@@ -46,5 +46,5 @@ public class EntityLayoutIntroduced extends StandardEvent {
     }
 
     @Index({EQ, UNIQUE})
-    public static SimpleIndex<EntityLayoutIntroduced, byte[]> FINGERPRINT = (object, queryOptions) -> object.fingerprint();
+    public static SimpleIndex<EntityLayoutIntroduced, byte[]> FINGERPRINT = EntityLayoutIntroduced::fingerprint;
 }

--- a/eventsourcing-migrations/src/main/java/com/eventsourcing/migrations/events/EntityLayoutReplaced.java
+++ b/eventsourcing-migrations/src/main/java/com/eventsourcing/migrations/events/EntityLayoutReplaced.java
@@ -36,8 +36,8 @@ public class EntityLayoutReplaced extends StandardEvent {
         this.replacement = replacement;
     }
 
-    public static SimpleIndex<EntityLayoutReplaced, byte[]> FINGERPRINT = (object, queryOptions) -> object.fingerprint();
+    public static SimpleIndex<EntityLayoutReplaced, byte[]> FINGERPRINT = EntityLayoutReplaced::fingerprint;
 
-    public static SimpleIndex<EntityLayoutReplaced, UUID> REPLACEMENT = (object, queryOptions) -> object.replacement();
+    public static SimpleIndex<EntityLayoutReplaced, UUID> REPLACEMENT = EntityLayoutReplaced::replacement;
 
 }

--- a/eventsourcing-queries/src/test/java/com/eventsourcing/queries/IsLatestEntityTest.java
+++ b/eventsourcing-queries/src/test/java/com/eventsourcing/queries/IsLatestEntityTest.java
@@ -7,10 +7,7 @@
  */
 package com.eventsourcing.queries;
 
-import com.eventsourcing.EntityHandle;
-import com.eventsourcing.EventStream;
-import com.eventsourcing.StandardCommand;
-import com.eventsourcing.StandardEvent;
+import com.eventsourcing.*;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Index;
 import com.eventsourcing.index.SimpleIndex;
@@ -50,10 +47,11 @@ public class IsLatestEntityTest extends RepositoryUsingTest {
         private String test;
         private UUID reference;
         @NonFinal
-        public static SimpleIndex<TestEvent, UUID> REFERENCE_ID = (object, queryOptions) -> object.reference();
+        public static SimpleIndex<TestEvent, UUID> REFERENCE_ID = TestEvent::reference;
+
         @NonFinal
         @Index({EQ, LT, GT})
-        public static SimpleIndex<TestEvent, HybridTimestamp> TIMESTAMP = (object, queryOptions) -> object.timestamp();
+        public static SimpleIndex<TestEvent, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
     }
 
     @Value

--- a/eventsourcing-queries/src/test/java/com/eventsourcing/queries/ModelQueriesTest.java
+++ b/eventsourcing-queries/src/test/java/com/eventsourcing/queries/ModelQueriesTest.java
@@ -9,6 +9,7 @@ package com.eventsourcing.queries;
 
 import com.eventsourcing.EventStream;
 import com.eventsourcing.StandardCommand;
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.index.SimpleAttribute;
 import com.eventsourcing.index.SimpleIndex;
@@ -29,7 +30,7 @@ public class ModelQueriesTest extends RepositoryUsingTest {
     }
 
     public static class TestEvent extends StandardEvent {
-        public static SimpleIndex<TestEvent, UUID> ID = (object, queryOptions) -> object.uuid();
+        public static SimpleIndex<TestEvent, UUID> ID = StandardEntity::uuid;
     }
 
     public static class TestCommand extends StandardCommand<TestEvent, UUID> {

--- a/eventsourcing-repository/src/main/java/boguspackage/BogusEvent.java
+++ b/eventsourcing-repository/src/main/java/boguspackage/BogusEvent.java
@@ -24,7 +24,7 @@ public class BogusEvent extends StandardEvent {
     private final String string;
 
     @Index({EQ, SC})
-    public static SimpleIndex<BogusEvent, String> ATTR = (object, queryOptions) -> object.string();
+    public static SimpleIndex<BogusEvent, String> ATTR = BogusEvent::string;
 
     @Builder
     public BogusEvent(HybridTimestamp timestamp, String string) {

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/AddressChanged.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/AddressChanged.java
@@ -7,6 +7,7 @@
  */
 package foodsourcing.events;
 
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Index;
@@ -38,35 +39,33 @@ public class AddressChanged extends StandardEvent {
     }
 
     @NonFinal
-    public static SimpleIndex<AddressChanged, UUID> ID = (addressChanged, queryOptions) -> addressChanged.uuid();
+    public static SimpleIndex<AddressChanged, UUID> ID = StandardEntity::uuid;
 
     @NonFinal
-    public static SimpleIndex<AddressChanged, UUID> REFERENCE_ID = (addressChanged, queryOptions) -> addressChanged
-            .reference();
+    public static SimpleIndex<AddressChanged, UUID> REFERENCE_ID = AddressChanged::reference;
 
     @NonFinal
     @Index({EQ, LT, GT})
-    public static SimpleIndex<AddressChanged, HybridTimestamp> TIMESTAMP =
-            (addressChanged, queryOptions) -> addressChanged.timestamp();
+    public static SimpleIndex<AddressChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
 
     @NonFinal
     @Index({EQ, LT, GT})
     public static SimpleIndex<AddressChanged, Double> BOUNDING_BOX_10K_LAT_START =
-            (addressChanged, queryOptions) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[0].getLatitudeInDegrees();
+            (addressChanged) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[0].getLatitudeInDegrees();
 
     @NonFinal
     @Index({EQ, LT, GT})
     public static SimpleIndex<AddressChanged, Double> BOUNDING_BOX_10K_LONG_START =
-            (addressChanged, queryOptions) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[0].getLongitudeInDegrees();
+            (addressChanged) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[0].getLongitudeInDegrees();
 
     @NonFinal
     @Index({EQ, LT, GT})
     public static SimpleIndex<AddressChanged, Double> BOUNDING_BOX_10K_LAT_END =
-            (addressChanged, queryOptions) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[1].getLatitudeInDegrees();
+            (addressChanged) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[1].getLatitudeInDegrees();
 
     @NonFinal
     @Index({EQ, LT, GT})
     public static SimpleIndex<AddressChanged, Double> BOUNDING_BOX_10K_LONG_END =
-            (addressChanged, queryOptions) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[1].getLongitudeInDegrees();
+            (addressChanged) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[1].getLongitudeInDegrees();
 
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/MenuItemAdded.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/MenuItemAdded.java
@@ -7,6 +7,7 @@
  */
 package foodsourcing.events;
 
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.index.SimpleIndex;
 import lombok.EqualsAndHashCode;
@@ -24,8 +25,8 @@ public class MenuItemAdded extends StandardEvent {
     private UUID reference;
 
     @NonFinal
-    public static SimpleIndex<MenuItemAdded, UUID> ID = (menuItemAdded, queryOptions) -> menuItemAdded.uuid();
+    public static SimpleIndex<MenuItemAdded, UUID> ID = StandardEntity::uuid;
 
     @NonFinal
-    public static SimpleIndex<MenuItemAdded, UUID> REFERENCE_ID = (menuItemAdded, queryOptions) -> menuItemAdded.reference();
+    public static SimpleIndex<MenuItemAdded, UUID> REFERENCE_ID = MenuItemAdded::reference;
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/PictureChanged.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/PictureChanged.java
@@ -7,6 +7,7 @@
  */
 package foodsourcing.events;
 
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Index;
@@ -30,11 +31,9 @@ public class PictureChanged extends StandardEvent implements Picture {
     private byte[] picture;
 
     @NonFinal
-    public static SimpleIndex<PictureChanged, UUID> REFERENCE_ID =
-            (pictureChanged, queryOptions) -> pictureChanged.reference();
+    public static SimpleIndex<PictureChanged, UUID> REFERENCE_ID = PictureChanged::reference;
 
     @NonFinal
     @Index({EQ, LT, GT})
-    public static SimpleIndex<PictureChanged, HybridTimestamp> TIMESTAMP =
-            (pictureChanged, queryOptions) -> pictureChanged.timestamp();
+    public static SimpleIndex<PictureChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/PriceChanged.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/PriceChanged.java
@@ -7,6 +7,7 @@
  */
 package foodsourcing.events;
 
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Index;
@@ -29,12 +30,10 @@ public class PriceChanged extends StandardEvent {
     private BigDecimal price;
 
     @NonFinal
-    public static SimpleIndex<PriceChanged, UUID> REFERENCE_ID =
-            (priceChanged, queryOptions) -> priceChanged.reference();
+    public static SimpleIndex<PriceChanged, UUID> REFERENCE_ID = PriceChanged::reference;
 
     @NonFinal
     @Index({EQ, LT, GT})
-    public static SimpleIndex<PriceChanged, HybridTimestamp> TIMESTAMP =
-            (priceChanged, queryOptions) -> priceChanged.timestamp();
+    public static SimpleIndex<PriceChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
 
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/RestaurantRegistered.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/RestaurantRegistered.java
@@ -7,6 +7,7 @@
  */
 package foodsourcing.events;
 
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.index.SimpleIndex;
 
@@ -14,7 +15,6 @@ import java.util.UUID;
 
 public class RestaurantRegistered extends StandardEvent {
 
-    public static SimpleIndex<RestaurantRegistered, UUID> ID =
-            (restaurantRegistered, queryOptions) -> restaurantRegistered.uuid();
+    public static SimpleIndex<RestaurantRegistered, UUID> ID = StandardEntity::uuid;
 
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/WorkingHoursChanged.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/WorkingHoursChanged.java
@@ -7,6 +7,7 @@
  */
 package foodsourcing.events;
 
+import com.eventsourcing.StandardEntity;
 import com.eventsourcing.StandardEvent;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.Index;
@@ -35,13 +36,11 @@ public class WorkingHoursChanged extends StandardEvent {
     private List<OpeningHours> openDuring;
 
     @NonFinal
-    public static SimpleIndex<WorkingHoursChanged, UUID> REFERENCE_ID =
-            (workingHoursChanged, queryOptions) -> workingHoursChanged.reference();
+    public static SimpleIndex<WorkingHoursChanged, UUID> REFERENCE_ID = WorkingHoursChanged::reference;
 
     @NonFinal
     @Index({EQ, LT, GT})
-    public static SimpleIndex<WorkingHoursChanged, HybridTimestamp> TIMESTAMP =
-            (workingHoursChanged, queryOptions) -> workingHoursChanged.timestamp();
+    public static SimpleIndex<WorkingHoursChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
 
     @Value
     public static class OpeningHoursBoundary
@@ -78,7 +77,7 @@ public class WorkingHoursChanged extends StandardEvent {
     @NonFinal
     @Index({EQ, LT, GT})
     public static MultiValueIndex<WorkingHoursChanged, OpeningHoursBoundary> OPENING_AT =
-            (workingHoursChanged, queryOptions) ->
+            (workingHoursChanged) ->
                     workingHoursChanged.openDuring().stream()
                             .map(openingHours ->
                                               new OpeningHoursBoundary(workingHoursChanged.dayOfWeek(), openingHours.from()))
@@ -87,13 +86,12 @@ public class WorkingHoursChanged extends StandardEvent {
     @NonFinal
     @Index({EQ, LT, GT})
     public static MultiValueIndex<WorkingHoursChanged, OpeningHoursBoundary> CLOSING_AT =
-            (workingHoursChanged, queryOptions) ->
+            (workingHoursChanged) ->
                     workingHoursChanged.openDuring().stream()
                                  .map(openingHours ->
                                               new OpeningHoursBoundary(workingHoursChanged.dayOfWeek(), openingHours.till()))
                                  .collect(Collectors.toList());
     @NonFinal
-    public static SimpleIndex<WorkingHoursChanged, DayOfWeek> DAY_OF_WEEK =
-            (workingHoursChanged, queryOptions) -> workingHoursChanged.dayOfWeek();
+    public static SimpleIndex<WorkingHoursChanged, DayOfWeek> DAY_OF_WEEK = WorkingHoursChanged::dayOfWeek;
 
 }


### PR DESCRIPTION
Most of the time, for most of use cases, there is no need for indices to be
aware of query options.

Also, having a two-arguments lambda prevents us from using
method references (which is a very common scenario when we need
to index a property as is)

Solution: make a one-argument functional interface a default
syntax in SimpleIndex and MultiValueIndex and add a #withQueryOptions
static helper to allow two-arguments functions to be supplied
to access query options.