### PR TITLE
Problem: it is impossible to know when query results change

### DIFF
--- a/eventsourcing-cep/build.gradle
+++ b/eventsourcing-cep/build.gradle
@@ -2,4 +2,5 @@ dependencies {
     compile project(':eventsourcing-core')
     compile project(':eventsourcing-queries')
     testCompile project(':eventsourcing-inmem')
+    testCompile project(':eventsourcing-repository')
 }

--- a/eventsourcing-core/build.gradle
+++ b/eventsourcing-core/build.gradle
@@ -13,5 +13,6 @@ dependencies {
     compile 'com.googlecode.cqengine:cqengine:2.8.0'
 
     testCompile project(':eventsourcing-inmem')
+    testCompile project(':eventsourcing-repository')
 
 }

--- a/eventsourcing-inmem/build.gradle
+++ b/eventsourcing-inmem/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
     compile project(':eventsourcing-core')
-    compile project(':eventsourcing-repository')
     compile project(':eventsourcing-layout')
 
     testCompile project(':eventsourcing-repository').sourceSets.test.output
+    testCompile project(':eventsourcing-repository')
 
     // Useful utilities
     compile 'com.google.guava:guava:19.0'

--- a/eventsourcing-migrations/build.gradle
+++ b/eventsourcing-migrations/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
     compile project(':eventsourcing-core')
     testCompile project(':eventsourcing-inmem')
+    testCompile project(':eventsourcing-repository')
 }

--- a/eventsourcing-queries/build.gradle
+++ b/eventsourcing-queries/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
     compile project(':eventsourcing-core')
     testCompile project(':eventsourcing-inmem')
+    testCompile project(':eventsourcing-repository')
 }

--- a/eventsourcing-repository/build.gradle
+++ b/eventsourcing-repository/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     compile project(':eventsourcing-core')
     compile project(':eventsourcing-cep')
+    compile project(':eventsourcing-inmem')
     compile project(':eventsourcing-migrations')
 }

--- a/eventsourcing-repository/src/main/java/com/eventsourcing/repository/QuerySubscriber.java
+++ b/eventsourcing-repository/src/main/java/com/eventsourcing/repository/QuerySubscriber.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.repository;
+
+import com.eventsourcing.Entity;
+import com.eventsourcing.EntityHandle;
+import com.eventsourcing.EntitySubscriber;
+import com.eventsourcing.Repository;
+import com.eventsourcing.index.IndexEngine;
+import com.eventsourcing.index.IndexLoader;
+import com.eventsourcing.index.MemoryIndexEngine;
+import com.googlecode.cqengine.IndexedCollection;
+import com.googlecode.cqengine.index.Index;
+import com.googlecode.cqengine.query.Query;
+import com.googlecode.cqengine.resultset.ResultSet;
+import lombok.SneakyThrows;
+import lombok.Value;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class QuerySubscriber implements EntitySubscriber<Entity> {
+
+    private Repository repository;
+
+    private final Set<IndexLoader> indexLoaders = new LinkedHashSet<>();
+
+    @Reference(cardinality = ReferenceCardinality.AT_LEAST_ONE)
+    public void bindIndexLoader(IndexLoader loader) {
+        indexLoaders.add(loader);
+    }
+
+    public void unbindIndexLoader(IndexLoader loader) {
+        indexLoaders.remove(loader);
+    }
+
+    @Reference
+    public void setRepository(Repository repository) {
+        this.repository = repository;
+    }
+
+    public void unsetRepository(Repository repository) {
+        this.repository = null;
+    }
+
+    public QuerySubscriber() {
+    }
+
+    public QuerySubscriber(Repository repository) {
+        this.repository = repository;
+    }
+
+    @Value
+    private static class QueryHolder<E extends Entity> {
+        private Class<E> klass;
+        private Query<EntityHandle<E>> query;
+
+        public int hashCode() {
+            return query.hashCode();
+        }
+    }
+    private Map<QueryHolder, Runnable> queries = new HashMap<>();
+
+    public <E extends Entity> void addQuery(Class<E> klass, Query<EntityHandle<E>> query,
+                                            Consumer<Query<EntityHandle<E>>> consumer) {
+        queries.put(new QueryHolder<>(klass, query), () -> consumer.accept(query));
+    }
+
+    public <E extends Entity> void removeQuery(Class<E> klass, Query<EntityHandle<E>> query) {
+        queries.remove(new QueryHolder<>(klass, query));
+    }
+
+
+    @SneakyThrows
+    @Override public void accept(Repository repository, Stream<EntityHandle<Entity>> entityStream) {
+        MemoryIndexEngine indexEngine = new MemoryIndexEngine();
+        indexEngine.setJournal(repository.getJournal());
+        indexEngine.setRepository(repository);
+
+        for (Class<? extends Entity> klass : repository.getCommands()) {
+            configureIndices(indexEngine, klass);
+        }
+        for (Class<? extends Entity> klass : repository.getEvents()) {
+            configureIndices(indexEngine, klass);
+        }
+
+        indexEngine.startAsync().awaitRunning();
+
+        entityStream.forEachOrdered(h -> {
+            Entity entity = h.get();
+            IndexedCollection<EntityHandle<Entity>> indexedCollection =
+                    indexEngine.getIndexedCollection((Class<Entity>)entity.getClass());
+            indexedCollection.add(h);
+        });
+
+        //
+        queries.forEach((query, runnable) -> {
+            IndexedCollection collection = indexEngine.getIndexedCollection(query.getKlass());
+            try (ResultSet resultSet = collection.retrieve(query.getQuery())) {
+                if (resultSet.isNotEmpty()) {
+                    runnable.run();
+                }
+            }
+        });
+
+        //
+        indexEngine.stopAsync().awaitTerminated();
+    }
+
+    private void configureIndices(IndexEngine engine, Class<? extends Entity> klass) throws IndexEngine.IndexNotSupported {
+        for (IndexLoader indexLoader : indexLoaders) {
+            Iterable<Index> indices = indexLoader.load(engine, klass);
+            for (Index i : indices) {
+                IndexedCollection<? extends EntityHandle<? extends Entity>> collection =
+                        engine.getIndexedCollection(klass);
+                boolean hasIndex = StreamSupport.stream(collection.getIndexes().spliterator(), false)
+                                                .anyMatch(index -> index.equals(i));
+                if (!hasIndex) {
+                    collection.addIndex(i);
+                }
+            }
+        }
+    }
+}

--- a/eventsourcing-repository/src/test/java/com/eventsourcing/repository/QuerySubscriberTest.java
+++ b/eventsourcing-repository/src/test/java/com/eventsourcing/repository/QuerySubscriberTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.repository;
+
+import com.eventsourcing.*;
+import com.eventsourcing.index.JavaStaticFieldIndexLoader;
+import com.eventsourcing.index.SimpleIndex;
+import com.eventsourcing.repository.QuerySubscriber;
+import com.googlecode.cqengine.query.Query;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import lombok.experimental.Accessors;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.eventsourcing.index.EntityQueryFactory.and;
+import static com.eventsourcing.index.EntityQueryFactory.equal;
+import static com.eventsourcing.index.EntityQueryFactory.existsIn;
+import static org.testng.Assert.*;
+
+public class QuerySubscriberTest extends RepositoryUsingTest {
+
+    public QuerySubscriberTest() {
+        super(QuerySubscriber.class.getPackage());
+    }
+
+    @Accessors(fluent = true)
+    public static class TestEvent extends StandardEvent {
+
+        @Getter
+        private String test;
+
+        public TestEvent(String test) {
+            this.test = test;
+        }
+
+        public static SimpleIndex<TestEvent, String> TEST = TestEvent::test;
+    }
+
+    @Accessors(fluent = true)
+    public static class AnotherEvent extends StandardEvent {
+
+        @Getter
+        private String test;
+
+        public AnotherEvent(String test) {
+            this.test = test;
+        }
+
+        public static SimpleIndex<AnotherEvent, String> TEST = AnotherEvent::test;
+    }
+
+    public static class TestCommand extends StandardCommand<Void, Void> {
+        @Override public EventStream<Void> events() throws Exception {
+            TestEvent event = new TestEvent("test");
+            return EventStream.ofWithState(null, event);
+        }
+    }
+
+    public static class AnotherCommand extends StandardCommand<Void, Void> {
+        @Override public EventStream<Void> events() throws Exception {
+            AnotherEvent event = new AnotherEvent("test");
+            return EventStream.ofWithState(null, event);
+        }
+    }
+
+    @Test(timeOut = 2000)
+    @SneakyThrows
+    public void test() {
+        Query<EntityHandle<TestEvent>> testQuery = equal(TestEvent.TEST, "test");
+        QuerySubscriber querySubscriber = new QuerySubscriber(repository);
+        querySubscriber.bindIndexLoader(new JavaStaticFieldIndexLoader());
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        querySubscriber.addQuery(TestEvent.class, testQuery, (q) -> future.complete(null));
+
+        repository.addEntitySubscriber(querySubscriber);
+        repository.publish(new TestCommand()).get();
+
+        future.get();
+    }
+
+    @Test(timeOut = 2000)
+    @SneakyThrows
+    public void testJoin() {
+        Query<EntityHandle<TestEvent>> testQuery = and(equal(TestEvent.TEST, "test"),
+                                                       existsIn(repository.getIndexEngine().getIndexedCollection
+                                                               (AnotherEvent.class),
+                                                                TestEvent.TEST, AnotherEvent.TEST));
+        QuerySubscriber querySubscriber = new QuerySubscriber(repository);
+        querySubscriber.bindIndexLoader(new JavaStaticFieldIndexLoader());
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        querySubscriber.addQuery(TestEvent.class, testQuery, (q) -> future.complete(null));
+
+        repository.addEntitySubscriber(querySubscriber);
+
+        repository.publish(new AnotherCommand()).get();
+        repository.publish(new TestCommand()).get();
+
+        future.get();
+    }
+
+    @Test
+    @SneakyThrows
+    public void testNegative() {
+        Query<EntityHandle<TestEvent>> testQuery = equal(TestEvent.TEST, "test1");
+        QuerySubscriber querySubscriber = new QuerySubscriber(repository);
+        querySubscriber.bindIndexLoader(new JavaStaticFieldIndexLoader());
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        querySubscriber.addQuery(TestEvent.class, testQuery, (q) -> future.complete(null));
+
+        repository.addEntitySubscriber(querySubscriber);
+        repository.publish(new TestCommand()).get();
+
+        try {
+            future.get(1, TimeUnit.SECONDS);
+            assertFalse(true, "should not receive a result");
+        } catch (TimeoutException e) {
+        }
+    }
+}

--- a/eventsourcing-repository/src/test/java/com/eventsourcing/repository/RepositoryUsingTest.java
+++ b/eventsourcing-repository/src/test/java/com/eventsourcing/repository/RepositoryUsingTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.repository;
+
+import com.eventsourcing.LocalLockProvider;
+import com.eventsourcing.PackageCommandSetProvider;
+import com.eventsourcing.PackageEventSetProvider;
+import com.eventsourcing.Repository;
+import com.eventsourcing.hlc.NTPServerTimeProvider;
+import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryJournal;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+public class RepositoryUsingTest {
+
+    private final Package[] packages;
+    protected Repository repository;
+    protected LocalLockProvider lockProvider;
+    protected NTPServerTimeProvider timeProvider;
+
+    public RepositoryUsingTest(Package ...packages) {
+        this.packages = packages;
+    }
+
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        repository =
+                StandardRepository.builder()
+                                  .journal(new MemoryJournal())
+                                  .indexEngine(new MemoryIndexEngine()).build();
+        repository.startAsync().awaitRunning();
+        // Add commands/events after the startup, to simulate production better
+        repository.addCommandSetProvider(new PackageCommandSetProvider(packages));
+        repository.addEventSetProvider(new PackageEventSetProvider(packages));
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        repository.stopAsync().awaitTerminated();
+    }
+}


### PR DESCRIPTION
Once a query is executed, it is impossible to know when the data queried
against has changed, leaving us to requery
at some time intervals.

Solution: implement a QuerySubscriber that would listen to all entities and
notify its own subscribers that a particular
query's set has changed.

It is rather simplistic for now, and I am not quite sure it is suitable for all scenarios,
but we can address this later, and if it doesn't work out, remove it. One of the areas
for improvement is to implement query-and-subscribe.
