### PR TITLE
Problem: getting a repository in an entity subscriber is difficult

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/EntitySubscriber.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/EntitySubscriber.java
@@ -40,11 +40,31 @@ public interface EntitySubscriber<T extends Entity> {
     }
 
     /**
+     * Defines a predicate for matching entities
+     * @param repository
+     * @param entity
+     * @return true if the entity should be returned
+     */
+    default boolean matches(Repository repository, T entity) {
+        return matches(entity);
+    }
+
+    /**
      * Used by {@link #accept(Stream)} to be invoked for every entity handle.
      * Does nothing by default.
      * @param entity
      */
     default void onEntity(EntityHandle<T> entity) {}
+
+    /**
+     * Used by {@link #accept(Stream)} to be invoked for every entity handle.
+     * Does nothing by default.
+     * @param repository
+     * @param entity
+     */
+    default void onEntity(Repository repository, EntityHandle<T> entity) {
+        onEntity(entity);
+    }
 
     /**
      * This method is invoked once the command is being committed and all relevant entities
@@ -55,4 +75,17 @@ public interface EntitySubscriber<T extends Entity> {
     default void accept(Stream<EntityHandle<T>> entityStream) {
         entityStream.forEach(this::onEntity);
     }
+
+    /**
+     * This method is invoked once the command is being committed and all relevant entities
+     * have been collected. It provides a default implementation that invokes {@link #onEntity(EntityHandle)}
+     * for every entity handle.
+     * @param repository;
+     * @param entityStream
+     */
+    default void accept(Repository repository,
+                        Stream<EntityHandle<T>> entityStream) {
+        entityStream.forEach(e -> onEntity(repository, e));
+    }
+
 }

--- a/eventsourcing-repository/src/main/java/com/eventsourcing/repository/CommandConsumerImpl.java
+++ b/eventsourcing-repository/src/main/java/com/eventsourcing/repository/CommandConsumerImpl.java
@@ -83,7 +83,7 @@ class CommandConsumerImpl extends AbstractService implements CommandConsumer {
                 .computeIfAbsent(event.getClass(), klass -> new ConcurrentIndexedCollection<>());
         coll.add(new ResolvedEntityHandle<>(event));
         subscribers.stream()
-                      .filter(s -> s.matches(event))
+                      .filter(s -> s.matches(repository, event))
                       .forEach(s -> subscriptions.get(s).add(event.uuid()));
     }
 
@@ -208,13 +208,13 @@ class CommandConsumerImpl extends AbstractService implements CommandConsumer {
                 coll.add(new ResolvedEntityHandle<>(command_));
                 subscriptions.entrySet().stream()
                              .forEach(entry -> entry.getKey()
-                                                    .accept(entry.getValue()
+                                                    .accept(repository, entry.getValue()
                                                                  .stream()
                                                                  .map(uuid -> new JournalEntityHandle<>(journal,
                                                                                                         uuid))));
                 subscribers.stream()
-                           .filter(s -> s.matches(command_))
-                           .forEach(s -> s.accept(Stream.of(commandHandle)));
+                           .filter(s -> s.matches(repository, command_))
+                           .forEach(s -> s.accept(repository, Stream.of(commandHandle)));
 
                 synchronized (timestamp) {
                     timestamp.update(txTimestamp);


### PR DESCRIPTION
In OSGi, when using Declarative Services, this results in a loop because
StandardRepository references EntitySubscribers.

In non-OSGi environments, a reference to repository must be passed to the
subscriber.

Solution: augment EntitySubscriber API to allow (optional) capture of the
repository.