### PR TITLE
Problem: impossible to index non-primitive attributes

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/JavaStaticFieldIndexLoader.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/JavaStaticFieldIndexLoader.java
@@ -10,11 +10,13 @@ package com.eventsourcing.index;
 import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
 import com.googlecode.cqengine.query.option.QueryOptions;
+import lombok.Getter;
 import lombok.SneakyThrows;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,7 +49,7 @@ public class JavaStaticFieldIndexLoader implements IndexLoader {
                     EntityIndex index = ((EntityIndex) field.get(null));
                     ParameterizedType type = (ParameterizedType) field.getGenericType();
                     Class<Entity> objectType = (Class<Entity>) type.getActualTypeArguments()[0];
-                    Class<Object> attributeType = (Class<Object>) type.getActualTypeArguments()[1];
+                    Type attributeType = type.getActualTypeArguments()[1];
                     Class<EntityHandle<Entity>> entityType = (Class<EntityHandle<Entity>>) field.getType()
                                                                                                 .getInterfaces()[0];
                     Attribute attribute;
@@ -93,12 +95,18 @@ public class JavaStaticFieldIndexLoader implements IndexLoader {
 
 
     class EntitySimpleAttribute extends SimpleAttribute<Entity, Object> {
+        @Getter
+        private final Type attributeReflectedType;
         private final EntityIndex index;
 
         public EntitySimpleAttribute(Class<Entity> objectType, Class<EntityHandle<Entity>> entityType,
-                                     Class<Object> attributeType,
+                                     Type attributeType,
                                      Field field, EntityIndex index) {
-            super(objectType, entityType, attributeType, field.getName());
+            super(objectType, entityType,
+                  (Class<Object>) (attributeType instanceof ParameterizedType ? ((ParameterizedType) attributeType)
+                          .getRawType(): attributeType),
+                  field.getName());
+            this.attributeReflectedType = attributeType;
             this.index = index;
         }
 
@@ -108,12 +116,16 @@ public class JavaStaticFieldIndexLoader implements IndexLoader {
     }
 
     class MultiValueEntityAttribute extends MultiValueAttribute<Entity, Object> {
+        @Getter
+        private final Type attributeReflectedType;
         private final EntityIndex index;
 
         public MultiValueEntityAttribute(Class<Entity> objectType, Class<EntityHandle<Entity>> entityType,
-                                         Class<Object> attributeType,
+                                         Type attributeType,
                                          Field field, EntityIndex index) {
-            super(objectType, entityType, attributeType, field.getName());
+            super(objectType, entityType, (Class<Object>) (attributeType instanceof ParameterizedType ? ((ParameterizedType) attributeType)
+                    .getRawType(): attributeType), field.getName());
+            this.attributeReflectedType = attributeType;
             this.index = index;
         }
 

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/MultiValueAttribute.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/MultiValueAttribute.java
@@ -11,9 +11,11 @@ import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
+import java.lang.reflect.Type;
+
 public abstract class MultiValueAttribute<O extends Entity, A>
         extends com.googlecode.cqengine.attribute.MultiValueAttribute<EntityHandle<O>, A>
-        implements Attribute<O, A> {
+        implements Attribute<O, A>, ReflectableAttribute<A> {
 
     private Class<O> objectType;
     private int cachedHashCode;

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/ReflectableAttribute.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/ReflectableAttribute.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.index;
+
+import java.lang.reflect.Type;
+
+public interface ReflectableAttribute<A> {
+    Class<A> getAttributeType();
+    default Type getAttributeReflectedType() {
+        return getAttributeType();
+    }
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/SimpleAttribute.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/SimpleAttribute.java
@@ -12,6 +12,7 @@ import com.eventsourcing.EntityHandle;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Getter;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
 
 /**
@@ -23,7 +24,7 @@ import java.util.Collections;
  */
 public abstract class SimpleAttribute<O extends Entity, A>
         extends com.googlecode.cqengine.attribute.SimpleAttribute<EntityHandle<O>, A>
-        implements Attribute<O, A> {
+        implements Attribute<O, A>, ReflectableAttribute<A> {
 
     private Class<O> objectType;
     private int cachedHashCode;

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/AbstractAttributeIndexTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/AbstractAttributeIndexTest.java
@@ -21,6 +21,7 @@ import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.SneakyThrows;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.*;
 
@@ -89,6 +90,12 @@ public class AbstractAttributeIndexTest {
     @SneakyThrows
     public void generics() {
         SimpleAttribute<Car, List<String>> FEATURES_LIST = new SimpleAttribute<Car, List<String>>("features") {
+
+            @SneakyThrows
+            @Override public Type getAttributeReflectedType() {
+                return AbstractAttributeIndexTest.class.getField("list").getGenericType();
+            }
+
             @Override
             public List<String> getValue(Car car, QueryOptions queryOptions) {
                 return car.getFeatures();
@@ -99,8 +106,8 @@ public class AbstractAttributeIndexTest {
 
         list = Arrays.asList("Hello");
         TypeResolver typeResolver = new TypeResolver();
-        ResolvedType klassType = typeResolver.resolve(List.class);
-        TypeHandler listTypeHandler = TypeHandler.lookup(klassType, getClass().getField("list").getAnnotatedType());
+        ResolvedType klassType = typeResolver.resolve(getClass().getField("list").getGenericType());
+        TypeHandler listTypeHandler = TypeHandler.lookup(klassType);
         ByteBuffer buffer = ByteBuffer.allocate(index.attributeSerializer.size(listTypeHandler, list));
         index.attributeSerializer.serialize(listTypeHandler, list, buffer);
         buffer.rewind();

--- a/eventsourcing-h2/src/main/java/com/eventsourcing/h2/index/HashIndex.java
+++ b/eventsourcing-h2/src/main/java/com/eventsourcing/h2/index/HashIndex.java
@@ -174,7 +174,7 @@ public class HashIndex<A, O extends Entity> extends AbstractHashingAttributeInde
 
         @Override
         public A next() {
-            return attributeDeserializer.deserialize(ByteBuffer.wrap(attrHashMap.get(cursor.next())));
+            return attributeDeserializer.deserialize(attrTypeHandler, ByteBuffer.wrap(attrHashMap.get(cursor.next())));
         }
     }
 
@@ -202,17 +202,17 @@ public class HashIndex<A, O extends Entity> extends AbstractHashingAttributeInde
     }
 
     private byte[] encodeAttribute(A value) {
-        int size = attributeSerializer.size(value);
+        int size = attributeSerializer.size(attrTypeHandler, value);
         ByteBuffer serializedAttribute = ByteBuffer.allocate(size);
-        attributeSerializer.serialize(value, serializedAttribute);
+        attributeSerializer.serialize(attrTypeHandler, value, serializedAttribute);
 
         return hashFunction.hashBytes(serializedAttribute.array()).asBytes();
     }
 
     private Entry encodeEntry(O object, A value) {
-        int attributeSize = attributeSerializer.size(value);
+        int attributeSize = attributeSerializer.size(attrTypeHandler, value);
         ByteBuffer serializedAttribute = ByteBuffer.allocate(attributeSize);
-        attributeSerializer.serialize(value, serializedAttribute);
+        attributeSerializer.serialize(attrTypeHandler, value, serializedAttribute);
 
         int objectSize = objectSerializer.size(object);
         ByteBuffer serializedObject = ByteBuffer.allocate(objectSize);
@@ -233,7 +233,7 @@ public class HashIndex<A, O extends Entity> extends AbstractHashingAttributeInde
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         byte[] hash = new byte[hashSize];
         buffer.get(hash);
-        return attributeDeserializer.deserialize(ByteBuffer.wrap(attrHashMap.get(hash)));
+        return attributeDeserializer.deserialize(attrTypeHandler, ByteBuffer.wrap(attrHashMap.get(hash)));
     }
 
     @Override

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/Layout.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/Layout.java
@@ -41,7 +41,7 @@ import java.util.stream.Stream;
  * <li>Has a getter (fluent or JavaBean style)</li>
  * <li>Has a matching parameter in the constructor (same parameter name or same name through {@link PropertyName}
  *     parameter annotation)</li>
- * <li>Must be of a supported type (see {@link TypeHandler#lookup(ResolvedType, AnnotatedType)})</li>
+ * <li>Must be of a supported type (see {@link TypeHandler#lookup(ResolvedType)})</li>
  * </ul>
  *
  * Additionally, inherited properties will be qualified by the following criteria:
@@ -49,7 +49,7 @@ import java.util.stream.Stream;
  *     <li>Has both a getter and a setter (fluent or JavaBean style)</li>
  *     <li>Has a matching parameter in the any parent's class constructor (same parameter name or same name through
  *     {@link PropertyName} parameter annotation)</li>
- *     <li>Must be of a supported type (see {@link TypeHandler#lookup(ResolvedType, AnnotatedType)})</li>
+ *     <li>Must be of a supported type (see {@link TypeHandler#lookup(ResolvedType)})</li>
  * </ul>
  * <p>
  *
@@ -235,10 +235,10 @@ public class Layout<T> {
 
             Method method = getter.get().get();
 
-            ResolvedType resolvedType = typeResolver.resolve(method.getReturnType());
+            ResolvedType resolvedType = typeResolver.resolve(method.getGenericReturnType());
             MethodHandle getterHandler = methodHandles.unreflect(method);
             Property<T> property = new Property<>(name, resolvedType,
-                                                   TypeHandler.lookup(resolvedType, method.getAnnotatedReturnType()),
+                                                   TypeHandler.lookup(resolvedType),
                                                    new GetterFunction<T>(getterHandler));
             properties.add(property);
             if (!parentClass) {

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/TypeHandler.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/TypeHandler.java
@@ -76,7 +76,7 @@ public interface TypeHandler {
      * @param type
      * @return
      */
-    static TypeHandler lookup(ResolvedType type, AnnotatedType annotatedType) throws TypeHandlerException {
+    static TypeHandler lookup(ResolvedType type) throws TypeHandlerException {
         try {
             if (type.isInstanceOf(Byte.TYPE) || type.isInstanceOf(Byte.class)) {
                 return BYTE_TYPE_HANDLER;
@@ -127,15 +127,15 @@ public interface TypeHandler {
             }
 
             if (type.isInstanceOf(List.class)) {
-                return new ListTypeHandler(annotatedType);
+                return new ListTypeHandler(type.getTypeParameters());
             }
 
             if (type.isInstanceOf(Map.class)) {
-                return new MapTypeHandler(annotatedType);
+                return new MapTypeHandler(type.getTypeParameters());
             }
 
             if (type.isInstanceOf(Optional.class)) {
-                return new OptionalTypeHandler(annotatedType);
+                return new OptionalTypeHandler(type.getTypeParameters());
             }
 
 

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/types/ListTypeHandler.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/types/ListTypeHandler.java
@@ -13,9 +13,7 @@ import com.fasterxml.classmate.TypeResolver;
 import com.google.common.primitives.Bytes;
 import lombok.Getter;
 
-import java.lang.reflect.AnnotatedParameterizedType;
-import java.lang.reflect.AnnotatedType;
-import java.lang.reflect.ParameterizedType;
+import java.util.List;
 
 public class ListTypeHandler implements TypeHandler {
     @Getter
@@ -25,20 +23,12 @@ public class ListTypeHandler implements TypeHandler {
         wrappedHandler = null;
     }
 
-    public ListTypeHandler(AnnotatedType annotatedType) throws TypeHandlerException {
-        if (!(annotatedType instanceof AnnotatedParameterizedType)) {
+    public ListTypeHandler(List<ResolvedType> typeParameters) throws TypeHandlerException {
+        if (typeParameters.size() != 1) {
             throw new IllegalArgumentException("List type parameter should be specified");
         }
-        AnnotatedParameterizedType parameterizedType = (AnnotatedParameterizedType) annotatedType;
-        AnnotatedType arg = parameterizedType.getAnnotatedActualTypeArguments()[0];
-        Class<?> klass;
-        if (arg.getType() instanceof ParameterizedType) {
-            klass = (Class<?>) ((ParameterizedType) (arg.getType())).getRawType();
-        } else {
-            klass = (Class<?>) arg.getType();
-        }
-        ResolvedType resolvedType = new TypeResolver().resolve(klass);
-        wrappedHandler = TypeHandler.lookup(resolvedType, arg);
+        ResolvedType resolvedType = new TypeResolver().resolve(typeParameters.get(0));
+        wrappedHandler = TypeHandler.lookup(resolvedType);
     }
 
     @Override

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/types/MapTypeHandler.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/types/MapTypeHandler.java
@@ -13,9 +13,7 @@ import com.fasterxml.classmate.TypeResolver;
 import com.google.common.primitives.Bytes;
 import lombok.Getter;
 
-import java.lang.reflect.AnnotatedParameterizedType;
-import java.lang.reflect.AnnotatedType;
-import java.lang.reflect.ParameterizedType;
+import java.util.List;
 
 public class MapTypeHandler implements TypeHandler {
 
@@ -29,30 +27,14 @@ public class MapTypeHandler implements TypeHandler {
         wrappedValueHandler = null;
     }
 
-    public MapTypeHandler(AnnotatedType annotatedType) throws TypeHandlerException {
-        if (!(annotatedType instanceof AnnotatedParameterizedType)) {
+    public MapTypeHandler(List<ResolvedType> typeParameters) throws TypeHandlerException {
+        if (typeParameters.size() != 2) {
             throw new IllegalArgumentException("Map type parameters should be specified");
         }
-        AnnotatedParameterizedType parameterizedType = (AnnotatedParameterizedType) annotatedType;
-        AnnotatedType key = parameterizedType.getAnnotatedActualTypeArguments()[0];
-        AnnotatedType value = parameterizedType.getAnnotatedActualTypeArguments()[1];
-        Class<?> keyClass;
-        if (key.getType() instanceof ParameterizedType) {
-            keyClass = (Class<?>) ((ParameterizedType) (key.getType())).getRawType();
-        } else {
-            keyClass = (Class<?>) key.getType();
-        }
-        Class<?> valueClass;
-        if (value.getType() instanceof ParameterizedType) {
-            valueClass = (Class<?>) ((ParameterizedType) (value.getType())).getRawType();
-        } else {
-            valueClass = (Class<?>) value.getType();
-        }
-        ResolvedType resolvedKeyType = new TypeResolver().resolve(keyClass);
-        wrappedKeyHandler = TypeHandler.lookup(resolvedKeyType, key);
-        ResolvedType resolvedValueType = new TypeResolver().resolve(valueClass);
-        wrappedValueHandler = TypeHandler.lookup(resolvedValueType, value);
-
+        ResolvedType resolvedKeyType = new TypeResolver().resolve(typeParameters.get(0));
+        wrappedKeyHandler = TypeHandler.lookup(resolvedKeyType);
+        ResolvedType resolvedValueType = new TypeResolver().resolve(typeParameters.get(1));
+        wrappedValueHandler = TypeHandler.lookup(resolvedValueType);
     }
 
     @Override

--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/types/OptionalTypeHandler.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/types/OptionalTypeHandler.java
@@ -13,9 +13,7 @@ import com.fasterxml.classmate.TypeResolver;
 import com.google.common.primitives.Bytes;
 import lombok.Getter;
 
-import java.lang.reflect.AnnotatedParameterizedType;
-import java.lang.reflect.AnnotatedType;
-import java.lang.reflect.ParameterizedType;
+import java.util.List;
 
 public class OptionalTypeHandler implements TypeHandler {
     @Getter
@@ -25,20 +23,12 @@ public class OptionalTypeHandler implements TypeHandler {
         wrappedHandler = null;
     }
 
-    public OptionalTypeHandler(AnnotatedType annotatedType) throws TypeHandlerException {
-        if (!(annotatedType instanceof AnnotatedParameterizedType)) {
-            throw new IllegalArgumentException("List type parameter should be specified");
+    public OptionalTypeHandler(List<ResolvedType> typeParameters) throws TypeHandlerException {
+        if (typeParameters.size() != 1) {
+            throw new IllegalArgumentException("Optional type parameters should be specified");
         }
-        AnnotatedParameterizedType parameterizedType = (AnnotatedParameterizedType) annotatedType;
-        AnnotatedType arg = parameterizedType.getAnnotatedActualTypeArguments()[0];
-        Class<?> klass;
-        if (arg.getType() instanceof ParameterizedType) {
-            klass = (Class<?>) ((ParameterizedType) (arg.getType())).getRawType();
-        } else {
-            klass = (Class<?>) arg.getType();
-        }
-        ResolvedType resolvedType = new TypeResolver().resolve(klass);
-        wrappedHandler = TypeHandler.lookup(resolvedType, arg);
+        ResolvedType resolvedType = new TypeResolver().resolve(typeParameters.get(0));
+        wrappedHandler = TypeHandler.lookup(resolvedType);
     }
 
     @Override

--- a/eventsourcing-layout/src/test/java/com/eventsourcing/layout/types/EnumTypeHandlerTest.java
+++ b/eventsourcing-layout/src/test/java/com/eventsourcing/layout/types/EnumTypeHandlerTest.java
@@ -27,9 +27,9 @@ public class EnumTypeHandlerTest {
 
     @Test @SneakyThrows
     public void fingerprintShape() {
-        TypeHandler typeHandlerA = TypeHandler.lookup(new TypeResolver().resolve(A.class), null);
-        TypeHandler typeHandlerA1 = TypeHandler.lookup(new TypeResolver().resolve(A1.class), null);
-        TypeHandler typeHandlerA2 = TypeHandler.lookup(new TypeResolver().resolve(A2.class), null);
+        TypeHandler typeHandlerA = TypeHandler.lookup(new TypeResolver().resolve(A.class));
+        TypeHandler typeHandlerA1 = TypeHandler.lookup(new TypeResolver().resolve(A1.class));
+        TypeHandler typeHandlerA2 = TypeHandler.lookup(new TypeResolver().resolve(A2.class));
         assertTrue(Arrays.equals(typeHandlerA.getFingerprint(), typeHandlerA1.getFingerprint()));
         assertFalse(Arrays.equals(typeHandlerA.getFingerprint(), typeHandlerA2.getFingerprint()));
     }

--- a/eventsourcing-layout/src/test/java/com/eventsourcing/layout/types/ListTypeHandlerTest.java
+++ b/eventsourcing-layout/src/test/java/com/eventsourcing/layout/types/ListTypeHandlerTest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.layout.types;
+
+import com.eventsourcing.layout.TypeHandler;
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.TypeResolver;
+import lombok.SneakyThrows;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.assertTrue;
+
+public class ListTypeHandlerTest {
+
+    public List<String> list;
+
+    @Test @SneakyThrows
+    public void parameters() {
+        ResolvedType type = new TypeResolver().resolve(getClass().getField("list").getGenericType());
+        TypeHandler typeHandler = TypeHandler.lookup(type);
+        assertTrue(typeHandler instanceof ListTypeHandler);
+    }
+}

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/PostgreSQLSerialization.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/PostgreSQLSerialization.java
@@ -413,10 +413,14 @@ public class PostgreSQLSerialization {
             s.setInt(i, (Integer) prepareValue(connection, typeHandler, value));
         } else
         if (typeHandler instanceof ListTypeHandler) {
-            s.setArray(i, (Array) prepareValue(connection, typeHandler, value));
+            /// TODO: review when this gets updated https://github.com/impossibl/pgjdbc-ng/issues/288
+//            s.setArray(i, (Array) prepareValue(connection, typeHandler, value));
+            s.setObject(i, ((Array)prepareValue(connection,typeHandler, value)).getArray());
         } else
         if (typeHandler instanceof MapTypeHandler) {
-            s.setArray(i, (Array) prepareValue(connection, typeHandler, value));
+            /// TODO: review when this gets updated https://github.com/impossibl/pgjdbc-ng/issues/288
+//            s.setArray(i, (Array) prepareValue(connection, typeHandler, value));
+            s.setObject(i, ((Array) prepareValue(connection, typeHandler, value)).getArray());
         } else
         if (typeHandler instanceof LongTypeHandler) {
             s.setLong(i, (Long) prepareValue(connection, typeHandler, value));

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/EqualityIndex.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/EqualityIndex.java
@@ -10,6 +10,7 @@ package com.eventsourcing.postgresql.index;
 import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
 import com.eventsourcing.index.Attribute;
+import com.eventsourcing.index.ReflectableAttribute;
 import com.eventsourcing.layout.Layout;
 import com.eventsourcing.layout.TypeHandler;
 import com.eventsourcing.postgresql.PostgreSQLSerialization;
@@ -65,8 +66,13 @@ public class EqualityIndex<A, O extends Entity> extends PostgreSQLAttributeIndex
         this.unique = unique;
         layout = Layout.forClass(attribute.getEffectiveObjectType());
         TypeResolver typeResolver = new TypeResolver();
-        ResolvedType resolvedType = typeResolver.resolve(attribute.getAttributeType());
-        attributeTypeHandler = TypeHandler.lookup(resolvedType, null);
+        ResolvedType resolvedType;
+        if (attribute instanceof ReflectableAttribute) {
+            resolvedType = typeResolver.resolve(((ReflectableAttribute) attribute).getAttributeReflectedType());
+        } else {
+            resolvedType = typeResolver.resolve(attribute.getAttributeType());
+        }
+        attributeTypeHandler = TypeHandler.lookup(resolvedType);
         init();
     }
 

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/NavigableIndex.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/NavigableIndex.java
@@ -93,7 +93,7 @@ public class NavigableIndex <A extends Comparable<A>, O extends Entity> extends 
         layout = Layout.forClass(attribute.getEffectiveObjectType());
         TypeResolver typeResolver = new TypeResolver();
         ResolvedType resolvedType = typeResolver.resolve(attribute.getAttributeType());
-        attributeTypeHandler = TypeHandler.lookup(resolvedType, null);
+        attributeTypeHandler = TypeHandler.lookup(resolvedType);
         init();
     }
 

--- a/eventsourcing-repository/src/test/java/com/eventsourcing/repository/RepositoryTest.java
+++ b/eventsourcing-repository/src/test/java/com/eventsourcing/repository/RepositoryTest.java
@@ -106,10 +106,12 @@ public abstract class RepositoryTest<T extends Repository> {
         @Index({EQ, SC})
         public static SimpleIndex<TestEvent, String> ATTR = TestEvent::string;
 
+        public static SimpleIndex<TestEvent, List<String>> ATTRL = TestEvent::strings;
+
         @Index
         public static MultiValueIndex<TestEvent, String> ATTRS = TestEvent::strings;
 
-        public Collection<String> strings() {
+        public List<String> strings() {
             return Arrays.asList(string);
         }
 
@@ -310,6 +312,9 @@ public abstract class RepositoryTest<T extends Repository> {
         assertTrue(coll.retrieve(contains(TestEvent.ATTR, "es")).isNotEmpty());
         assertEquals(coll.retrieve(equal(TestEvent.ATTR, "test")).uniqueResult().get().string(), "test");
         assertEquals(coll.retrieve(equal(TestEvent.ATTRS, "test")).uniqueResult().get().string(), "test");
+        assertEquals(coll.retrieve(equal(TestEvent.ATTRL, Arrays.asList("test"))).uniqueResult().get().string(),
+                     "test");
+        assertTrue(coll.retrieve(equal(TestEvent.ATTRL, Arrays.asList("test1"))).isEmpty());
 
         assertTrue(coll1.retrieve(equal(RepositoryTestCommand.ATTR, "test")).isNotEmpty());
         assertTrue(coll1.retrieve(contains(RepositoryTestCommand.ATTR, "es")).isNotEmpty());


### PR DESCRIPTION
For example, an attribute of a List<String> will result in a runtime exception of
an invalid type cast.

Solution: simplify type handler resolution and ensure typing information gets
through correctly.

Also, address an issue discovered in pgjdbc-ng
(https://github.com/impossibl/pgjdbc-ng/issues/288), to be reviewed again
later.

Also, fix discovered serializing issues in eventsourcing-h2 indexing.