### PR TITLE
Problem: exceptionally terminated commands' result() is called

### DIFF
--- a/eventsourcing-repository/src/main/java/com/eventsourcing/repository/CommandConsumerImpl.java
+++ b/eventsourcing-repository/src/main/java/com/eventsourcing/repository/CommandConsumerImpl.java
@@ -220,15 +220,15 @@ class CommandConsumerImpl extends AbstractService implements CommandConsumer {
                     timestamp.update(txTimestamp);
                 }
 
-                T result = command.result(eventStream.getState(), repository, lockProvider);
-                lockProvider.release();
 
                 if (exception == null) {
+                    T result = command.result(eventStream.getState(), repository, lockProvider);
+                    lockProvider.release();
                     future.complete(result);
                 } else {
+                    lockProvider.release();
                     future.completeExceptionally(exception);
                 }
-
             }
 
         }


### PR DESCRIPTION
If a command has terminated exceptionally, it doesn't make a whole lot of sense
to call its `#result()` as it, at best, it won't be consistent.

What makes it worse, we currently call it with a state of the new event stream
that encapsulates abnormal termination events which always has a `null` state
and that's what being passed to `#result()`.

Solution: don't call `Command#result()` if the command has terminated
exceptionally.