### PR TITLE
Problem: EntitySubscriber#accept(Stream) leads to confusing bugs

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/EntitySubscriber.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/EntitySubscriber.java
@@ -71,6 +71,7 @@ public interface EntitySubscriber<T extends Entity> {
      * have been collected. It provides a default implementation that invokes {@link #onEntity(EntityHandle)}
      * for every entity handle.
      * @param entityStream
+     * @deprecated To avoid confusion, this method has been deprecated. Use {@link #accept(Repository, Stream)} instead.
      */
     default void accept(Stream<EntityHandle<T>> entityStream) {
         entityStream.forEach(this::onEntity);


### PR DESCRIPTION
Specifically, if one doesn't need a repository, and overrides EntitySubscriber#accept(Stream),
when command is processed, EntitySubscriber#accept(Repository, Stream) is invoked
which is set up to call #onEntity(Repository, entity) on all entities, entirely bypassing
EntitySubscriber#accept(Stream).

Solution: deprecate EntitySubscriber#accept(Stream)
