### PR TITLE
Problem: using non-final index definitions is problematic

### DIFF
--- a/docs/getting_started/indexing.md
+++ b/docs/getting_started/indexing.md
@@ -5,7 +5,7 @@ find restaurant's address changes by its ID. In `AddressChanged`, add this simpl
 
 ```java
 @NonFinal
-public static SimpleIndex<AddressChanged, UUID> REFERENCE_ID = AddressChanged::reference;
+public static SimpleIndex<AddressChanged, UUID> REFERENCE_ID = SimpleIndex.as(AddressChanged::reference);
 ```
 
 If you want to index a comparable, such as event's timestamp (it's a very common scenario!), you need to declare index properties:
@@ -13,7 +13,7 @@ If you want to index a comparable, such as event's timestamp (it's a very common
 ```java
 @NonFinal
 @Index({EQ, LT, GT})
-public static SimpleIndex<AddressChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
+public static SimpleIndex<AddressChanged, HybridTimestamp> TIMESTAMP = SimpleIndex.as(StandardEntity::timestamp);
 ```
 
 Indexing is not limited to producing just one value. In some cases, like
@@ -23,10 +23,10 @@ indexing working hours schedule in `WorkingHoursChanged`, an index can produce a
 @NonFinal
 @Index({EQ, LT, GT})
 public static MultiValueIndex<WorkingHoursChanged, OpeningHoursBoundary> OPENING_AT =
-        (workingHoursChanged) ->
+        SimpleIndex.as((workingHoursChanged) ->
                 workingHoursChanged.openDuring().stream()
                         .map(openingHours ->
                              new OpeningHoursBoundary(workingHoursChanged.dayOfWeek(),
                                                   openingHours.from()))
-                        .collect(Collectors.toList());
+                        .collect(Collectors.toList()));
 ```

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Deleted.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Deleted.java
@@ -38,12 +38,12 @@ public class Deleted extends StandardEvent {
     final UUID reference;
 
     @Index
-    public static SimpleIndex<Deleted, UUID> ID = StandardEntity::uuid;
+    public final static SimpleIndex<Deleted, UUID> ID = SimpleIndex.as(StandardEntity::uuid);
 
-    public static SimpleIndex<Deleted, UUID> REFERENCE_ID = Deleted::reference;
+    public final static SimpleIndex<Deleted, UUID> REFERENCE_ID = SimpleIndex.as(Deleted::reference);
 
     @Index({EQ, LT, GT})
-    public static SimpleIndex<Deleted, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
+    public final static SimpleIndex<Deleted, HybridTimestamp> TIMESTAMP = SimpleIndex.as(StandardEntity::timestamp);
 
     @LayoutConstructor
     public Deleted(UUID reference) {

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/DescriptionChanged.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/DescriptionChanged.java
@@ -49,10 +49,10 @@ public class DescriptionChanged extends StandardEvent {
         this.description = description;
     }
 
-    public static SimpleIndex<DescriptionChanged, UUID> REFERENCE_ID = DescriptionChanged::reference;
+    public final static SimpleIndex<DescriptionChanged, UUID> REFERENCE_ID = SimpleIndex.as(DescriptionChanged::reference);
 
-    public static SimpleIndex<DescriptionChanged, String> DESCRIPTION = DescriptionChanged::description;
+    public final static SimpleIndex<DescriptionChanged, String> DESCRIPTION = SimpleIndex.as(DescriptionChanged::description);
 
     @Index({LT, GT, EQ})
-    public static SimpleIndex<DescriptionChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
+    public final static SimpleIndex<DescriptionChanged, HybridTimestamp> TIMESTAMP = SimpleIndex.as(StandardEntity::timestamp);
 }

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/NameChanged.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/NameChanged.java
@@ -49,10 +49,10 @@ public class NameChanged extends StandardEvent {
         this.name = name;
     }
 
-    public static SimpleIndex<NameChanged, UUID> REFERENCE_ID = NameChanged::reference;
+    public final static SimpleIndex<NameChanged, UUID> REFERENCE_ID = SimpleIndex.as(NameChanged::reference);
 
-    public static SimpleIndex<NameChanged, String> NAME = NameChanged::name;
+    public final static SimpleIndex<NameChanged, String> NAME = SimpleIndex.as(NameChanged::name);
 
     @Index({LT, GT, EQ})
-    public static SimpleIndex<NameChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
+    public final static SimpleIndex<NameChanged, HybridTimestamp> TIMESTAMP = SimpleIndex.as(StandardEntity::timestamp);
 }

--- a/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Undeleted.java
+++ b/eventsourcing-cep/src/main/java/com/eventsourcing/cep/events/Undeleted.java
@@ -36,10 +36,10 @@ public class Undeleted extends StandardEvent {
     @Getter
     final UUID deleted;
 
-    public static SimpleIndex<Undeleted, UUID> DELETED_ID = Undeleted::deleted;
+    public final static SimpleIndex<Undeleted, UUID> DELETED_ID = SimpleIndex.as(Undeleted::deleted);
 
     @Index({EQ, LT, GT})
-    public static SimpleIndex<Undeleted, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
+    public final static SimpleIndex<Undeleted, HybridTimestamp> TIMESTAMP = SimpleIndex.as(StandardEntity::timestamp);
 
     @LayoutConstructor
     public Undeleted(UUID deleted) {

--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DeletedProtocolTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/DeletedProtocolTest.java
@@ -43,7 +43,7 @@ public class DeletedProtocolTest extends RepositoryUsingTest {
         }
     }
     public static class Created extends StandardEvent {
-        public static SimpleIndex<Created, UUID> ID = StandardEntity::uuid;
+        public final static SimpleIndex<Created, UUID> ID = SimpleIndex.as(StandardEntity::uuid);
     }
 
     @Accessors(fluent = true)

--- a/eventsourcing-core/src/main/java/com/eventsourcing/events/CommandTerminatedExceptionally.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/events/CommandTerminatedExceptionally.java
@@ -19,5 +19,5 @@ import java.util.UUID;
 @LayoutName("rfc.eventsourcing.com/spec:9/RIG/#CommandTerminatedExceptionally")
 public class CommandTerminatedExceptionally extends StandardEvent {
 
-    public static SimpleIndex<CommandTerminatedExceptionally, UUID> ID = StandardEntity::uuid;
+    public final static SimpleIndex<CommandTerminatedExceptionally, UUID> ID = SimpleIndex.as(StandardEntity::uuid);
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/events/EventCausalityEstablished.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/events/EventCausalityEstablished.java
@@ -35,7 +35,7 @@ public class EventCausalityEstablished extends StandardEvent {
         this.command = command;
     }
 
-    public static SimpleIndex<EventCausalityEstablished, UUID> EVENT = EventCausalityEstablished::event;
+    public final static SimpleIndex<EventCausalityEstablished, UUID> EVENT = SimpleIndex.as(EventCausalityEstablished::event);
 
-    public static SimpleIndex<EventCausalityEstablished, UUID> COMMAND = EventCausalityEstablished::command;
+    public final static SimpleIndex<EventCausalityEstablished, UUID> COMMAND = SimpleIndex.as(EventCausalityEstablished::command);
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/events/JavaExceptionOccurred.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/events/JavaExceptionOccurred.java
@@ -70,6 +70,6 @@ public class JavaExceptionOccurred extends StandardEvent {
                 map(StackTraceElement::new).collect(Collectors.toList());
     }
 
-    public static SimpleIndex<JavaExceptionOccurred, UUID> ID = StandardEntity::uuid;
+    public final static SimpleIndex<JavaExceptionOccurred, UUID> ID = SimpleIndex.as(StandardEntity::uuid);
 
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/EntityQueryFactory.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/EntityQueryFactory.java
@@ -27,7 +27,6 @@ import java.util.regex.Pattern;
  */
 public interface EntityQueryFactory {
 
-
     /**
      * Creates an {@link Equal} query which asserts that an attribute equals a certain value.
      *
@@ -1088,4 +1087,5 @@ public interface EntityQueryFactory {
     static <O extends Entity> Query<EntityHandle<O>> none(Class<O> objectType) {
         return new None<>(objectType);
     }
+
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/IndexWithAttribute.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/IndexWithAttribute.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.index;
+
+import com.eventsourcing.Entity;
+
+public interface IndexWithAttribute<O extends Entity, A> {
+    Attribute<O, A> getAttribute();
+    void setAttribute(Attribute<O, A> attribute);
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/JavaStaticFieldIndexLoader.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/JavaStaticFieldIndexLoader.java
@@ -19,13 +19,16 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiFunction;
 
 import com.googlecode.cqengine.index.Index;
+import lombok.extern.slf4j.Slf4j;
 import org.osgi.service.component.annotations.Component;
 
 import static com.eventsourcing.index.IndexEngine.IndexFeature.EQ;
 
 @Component
+@Slf4j
 public class JavaStaticFieldIndexLoader implements IndexLoader {
 
     @SneakyThrows
@@ -39,9 +42,6 @@ public class JavaStaticFieldIndexLoader implements IndexLoader {
             for (Field field : klass.getDeclaredFields()) {
                 if (Modifier.isStatic(field.getModifiers()) && Modifier.isPublic(field.getModifiers()) &&
                         EntityIndex.class.isAssignableFrom(field.getType())) {
-                    if (Modifier.isFinal(field.getModifiers())) {
-                        throw new IllegalArgumentException("Index attribute " + field + " can't be declared final");
-                    }
 
                     com.eventsourcing.index.Index annotation = field
                             .getAnnotation(com.eventsourcing.index.Index.class);
@@ -56,34 +56,25 @@ public class JavaStaticFieldIndexLoader implements IndexLoader {
 
                     if (SimpleIndex.class.isAssignableFrom(field.getType())) {
                         attribute = new EntitySimpleAttribute(objectType, entityType, attributeType, field, index);
-                        field.set(null, new SimpleIndex() {
-                            @Override public Attribute getAttribute() {
-                                return attribute;
-                            }
-
-                            @Override public Object getValue(Entity object) {
-                                return ((SimpleIndex) index).getValue(object);
-                            }
-
-                            @Override public Object getValue(Entity object, QueryOptions queryOptions) {
-                                return ((SimpleIndex) index).getValue(object, queryOptions);
-                            }
-                        });
+                        if (index instanceof IndexWithAttribute) {
+                            ((IndexWithAttribute) index).setAttribute(attribute);
+                        } else {
+                            log.warn("Non-final index definitions are deprecated, use SimpleIndex.as() instead");
+                            WrappedSimpleIndex wrappedIndex = new WrappedSimpleIndex<>((BiFunction<Entity, QueryOptions, Object>) ((SimpleIndex) index)::getValue);
+                            wrappedIndex.setAttribute(attribute);
+                            field.set(null, wrappedIndex);
+                        }
                     } else {
                         attribute = new MultiValueEntityAttribute(objectType, entityType, attributeType, field, index);
-                        field.set(null, new MultiValueIndex() {
-                            @Override public Attribute getAttribute() {
-                                return attribute;
-                            }
-
-                            @Override public Iterable getValues(Entity object) {
-                                return ((MultiValueIndex)index).getValues(object);
-                            }
-
-                            @Override public Iterable getValues(Entity object, QueryOptions queryOptions) {
-                                return index.getValues(object, queryOptions);
-                            }
-                        });
+                        if (index instanceof IndexWithAttribute) {
+                            ((IndexWithAttribute) index).setAttribute(attribute);
+                        } else {
+                            log.warn("Non-final index definitions are deprecated, use MultiValueIndex.as() instead");
+                            WrappedMultiValueIndex wrappedIndex = new WrappedMultiValueIndex(((BiFunction<Entity,
+                                    QueryOptions, Object>) ((MultiValueIndex) index)::getValues));
+                            wrappedIndex.setAttribute(attribute);
+                            field.set(null, wrappedIndex);
+                        }
                     }
                     indices.add(engine.getIndexOnAttribute(attribute, features));
                 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/MultiValueIndex.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/MultiValueIndex.java
@@ -11,6 +11,7 @@ import com.eventsourcing.Entity;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Designates a multiple values index using a functional interface
@@ -44,6 +45,19 @@ public interface MultiValueIndex<O extends Entity, A> extends EntityIndex<O, A> 
 
     Iterable<A> getValues(O object);
 
+
+    /**
+     * Creates a MultiValueIndex with a function that can access {@link QueryOptions}
+     * @param function
+     * @param <O>
+     * @param <A>
+     * @return
+     */
+    static <O extends Entity, A> MultiValueIndex<O, A> as(Function<O, Iterable<A>> function) {
+        return new WrappedMultiValueIndex<>(function);
+    }
+
+
     /**
      * Creates a MultiValueIndex with a function that can access {@link QueryOptions}
      * @param function
@@ -53,16 +67,9 @@ public interface MultiValueIndex<O extends Entity, A> extends EntityIndex<O, A> 
      */
     static <O extends Entity, A> MultiValueIndex<O, A>
         withQueryOptions(BiFunction<O, QueryOptions, Iterable<A>> function) {
-        return new MultiValueIndex<O, A>() {
-            @Override public Iterable<A> getValues(O object, QueryOptions queryOptions) {
-                return function.apply(object, queryOptions);
-            }
-
-            @Override public Iterable<A> getValues(O object) {
-                return function.apply(object, EntityQueryFactory.noQueryOptions());
-            }
-        };
+        return new WrappedMultiValueIndex<>(function);
     }
+
 
     default Attribute<O, A> getAttribute() {
         throw new IllegalStateException("Index " + this + " hasn't been initialized yet");

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/SimpleIndex.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/SimpleIndex.java
@@ -12,6 +12,7 @@ import com.googlecode.cqengine.query.option.QueryOptions;
 
 import java.util.Collections;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Designates a simple (single value) index using a functional interface.
@@ -45,6 +46,18 @@ public interface SimpleIndex<O extends Entity, A> extends EntityIndex<O, A> {
     A getValue(O object);
 
     /**
+     * Creates a SimpleIndex
+     *
+     * @param function
+     * @param <O>
+     * @param <A>
+     * @return
+     */
+    static <O extends Entity, A> SimpleIndex<O, A> as(Function<O, A> function) {
+        return new WrappedSimpleIndex<>(function);
+    }
+
+    /**
      * Creates a SimpleIndex with a function that can access {@link QueryOptions}
      *
      * @param function
@@ -53,15 +66,7 @@ public interface SimpleIndex<O extends Entity, A> extends EntityIndex<O, A> {
      * @return
      */
     static <O extends Entity, A> SimpleIndex<O, A> withQueryOptions(BiFunction<O, QueryOptions, A> function) {
-        return new SimpleIndex<O, A>() {
-            @Override public A getValue(O object, QueryOptions queryOptions) {
-                return function.apply(object, queryOptions);
-            }
-
-            @Override public A getValue(O object) {
-                return function.apply(object, EntityQueryFactory.noQueryOptions());
-            }
-        };
+        return new WrappedSimpleIndex<>(function);
     }
 
     default Iterable<A> getValues(O object, QueryOptions queryOptions) {

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/WrappedMultiValueIndex.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/WrappedMultiValueIndex.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.index;
+
+import com.eventsourcing.Entity;
+import com.googlecode.cqengine.query.option.QueryOptions;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static com.eventsourcing.index.EntityQueryFactory.noQueryOptions;
+
+class WrappedMultiValueIndex<O extends Entity, A, I extends Iterable<A>> implements MultiValueIndex<O, A>,
+        IndexWithAttribute<O, A> {
+    private final BiFunction<O, QueryOptions, I> index;
+    @Getter @Setter
+    private Attribute<O, A> attribute;
+
+    public WrappedMultiValueIndex(Function<O, I> index) {this.index = (object, queryOptions) -> index.apply(object);}
+    public WrappedMultiValueIndex(BiFunction<O, QueryOptions, I> index) {this.index = index;}
+
+
+    @Override public Iterable<A> getValues(O object) {
+        return index.apply(object, noQueryOptions());
+    }
+
+    @Override public Iterable<A> getValues(O object, QueryOptions queryOptions) {
+        return index.apply(object, queryOptions);
+    }
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/WrappedSimpleIndex.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/WrappedSimpleIndex.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.index;
+
+import com.eventsourcing.Entity;
+import com.googlecode.cqengine.attribute.*;
+import com.googlecode.cqengine.query.option.QueryOptions;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static com.eventsourcing.index.EntityQueryFactory.noQueryOptions;
+
+class WrappedSimpleIndex<O extends Entity, A> implements SimpleIndex<O, A>, IndexWithAttribute<O, A> {
+    private final BiFunction<O, QueryOptions, A> index;
+    @Getter @Setter
+    private Attribute<O, A> attribute;
+
+    public WrappedSimpleIndex(Function<O, A> index) {this.index = (e, queryOptions) -> index.apply(e);}
+    public WrappedSimpleIndex(BiFunction<O, QueryOptions, A> index) {this.index = index;}
+
+    @Override public A getValue(O object) {
+        return index.apply(object, noQueryOptions());
+    }
+
+    @Override public A getValue(O object, QueryOptions queryOptions) {
+        return index.apply(object, queryOptions);
+    }
+}

--- a/eventsourcing-core/src/test/java/boguspackage/BogusEvent.java
+++ b/eventsourcing-core/src/test/java/boguspackage/BogusEvent.java
@@ -24,7 +24,7 @@ public class BogusEvent extends StandardEvent {
     private final String string;
 
     @Index({EQ, SC})
-    public static SimpleIndex<BogusEvent, String> ATTR = BogusEvent::string;
+    public final static SimpleIndex<BogusEvent, String> ATTR = SimpleIndex.as(BogusEvent::string);
 
     @Builder
     public BogusEvent(HybridTimestamp timestamp, String string) {

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexEngineTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/IndexEngineTest.java
@@ -86,10 +86,10 @@ public abstract class IndexEngineTest<T extends IndexEngine> {
         @Getter @Accessors(chain = true)
         private final String anotherString;
 
-        public static SimpleIndex<TestEvent, String> ANOTHER_ATTR = TestEvent::getAnotherString;
+        public final static SimpleIndex<TestEvent, String> ANOTHER_ATTR = SimpleIndex.as(TestEvent::getAnotherString);
 
         @Index
-        public static SimpleIndex<TestEvent, String> ATTR = TestEvent::getString;
+        public final static SimpleIndex<TestEvent, String> ATTR = SimpleIndex.as(TestEvent::getString);
     }
 
     @Accessors(fluent = true)

--- a/eventsourcing-migrations/src/main/java/com/eventsourcing/migrations/events/EntityLayoutIntroduced.java
+++ b/eventsourcing-migrations/src/main/java/com/eventsourcing/migrations/events/EntityLayoutIntroduced.java
@@ -46,5 +46,5 @@ public class EntityLayoutIntroduced extends StandardEvent {
     }
 
     @Index({EQ, UNIQUE})
-    public static SimpleIndex<EntityLayoutIntroduced, byte[]> FINGERPRINT = EntityLayoutIntroduced::fingerprint;
+    public final static SimpleIndex<EntityLayoutIntroduced, byte[]> FINGERPRINT = SimpleIndex.as(EntityLayoutIntroduced::fingerprint);
 }

--- a/eventsourcing-migrations/src/main/java/com/eventsourcing/migrations/events/EntityLayoutReplaced.java
+++ b/eventsourcing-migrations/src/main/java/com/eventsourcing/migrations/events/EntityLayoutReplaced.java
@@ -36,8 +36,8 @@ public class EntityLayoutReplaced extends StandardEvent {
         this.replacement = replacement;
     }
 
-    public static SimpleIndex<EntityLayoutReplaced, byte[]> FINGERPRINT = EntityLayoutReplaced::fingerprint;
+    public final static SimpleIndex<EntityLayoutReplaced, byte[]> FINGERPRINT = SimpleIndex.as(EntityLayoutReplaced::fingerprint);
 
-    public static SimpleIndex<EntityLayoutReplaced, UUID> REPLACEMENT = EntityLayoutReplaced::replacement;
+    public final static SimpleIndex<EntityLayoutReplaced, UUID> REPLACEMENT = SimpleIndex.as(EntityLayoutReplaced::replacement);
 
 }

--- a/eventsourcing-queries/src/test/java/com/eventsourcing/queries/IsLatestEntityTest.java
+++ b/eventsourcing-queries/src/test/java/com/eventsourcing/queries/IsLatestEntityTest.java
@@ -46,12 +46,12 @@ public class IsLatestEntityTest extends RepositoryUsingTest {
     public static class TestEvent extends StandardEvent {
         private String test;
         private UUID reference;
-        @NonFinal
-        public static SimpleIndex<TestEvent, UUID> REFERENCE_ID = TestEvent::reference;
 
-        @NonFinal
+        public final static SimpleIndex<TestEvent, UUID> REFERENCE_ID = SimpleIndex.as(TestEvent::reference);
+
+
         @Index({EQ, LT, GT})
-        public static SimpleIndex<TestEvent, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
+        public final static SimpleIndex<TestEvent, HybridTimestamp> TIMESTAMP = SimpleIndex.as(StandardEntity::timestamp);
     }
 
     @Value

--- a/eventsourcing-queries/src/test/java/com/eventsourcing/queries/ModelQueriesTest.java
+++ b/eventsourcing-queries/src/test/java/com/eventsourcing/queries/ModelQueriesTest.java
@@ -30,7 +30,7 @@ public class ModelQueriesTest extends RepositoryUsingTest {
     }
 
     public static class TestEvent extends StandardEvent {
-        public static SimpleIndex<TestEvent, UUID> ID = StandardEntity::uuid;
+        public final static SimpleIndex<TestEvent, UUID> ID = SimpleIndex.as(StandardEntity::uuid);
     }
 
     public static class TestCommand extends StandardCommand<TestEvent, UUID> {

--- a/eventsourcing-repository/src/test/java/boguspackage/BogusEvent.java
+++ b/eventsourcing-repository/src/test/java/boguspackage/BogusEvent.java
@@ -24,7 +24,7 @@ public class BogusEvent extends StandardEvent {
     private final String string;
 
     @Index({EQ, SC})
-    public static SimpleIndex<BogusEvent, String> ATTR = BogusEvent::string;
+    public final static SimpleIndex<BogusEvent, String> ATTR = SimpleIndex.as(BogusEvent::string);
 
     @Builder
     public BogusEvent(HybridTimestamp timestamp, String string) {

--- a/eventsourcing-repository/src/test/java/com/eventsourcing/repository/RepositoryTest.java
+++ b/eventsourcing-repository/src/test/java/com/eventsourcing/repository/RepositoryTest.java
@@ -105,10 +105,14 @@ public abstract class RepositoryTest<T extends Repository> {
         private final String string;
 
         @Index({EQ, SC})
-        public static SimpleIndex<TestEvent, String> ATTR = TestEvent::string;
+        public final static SimpleIndex<TestEvent, String> ATTR = SimpleIndex.as(TestEvent::string);
+
+        @Index({EQ, SC})
+        @Deprecated
+        public final static SimpleIndex<TestEvent, String> ATTR_DEP = SimpleIndex.as(TestEvent::string);
 
         @Index
-        public static MultiValueIndex<TestEvent, String> ATTRS = TestEvent::strings;
+        public final static MultiValueIndex<TestEvent, String> ATTRS = MultiValueIndex.as(TestEvent::strings);
 
         public List<String> strings() {
             return Arrays.asList(string);
@@ -149,7 +153,7 @@ public abstract class RepositoryTest<T extends Repository> {
         }
 
         @Index({EQ, SC})
-        public static SimpleIndex<RepositoryTestCommand, String> ATTR = RepositoryTestCommand::getValue;
+        public final static SimpleIndex<RepositoryTestCommand, String> ATTR = SimpleIndex.as(RepositoryTestCommand::getValue);
 
     }
 
@@ -312,6 +316,7 @@ public abstract class RepositoryTest<T extends Repository> {
 
         repository.publish(RepositoryTestCommand.builder().build()).get();
         assertTrue(coll.retrieve(equal(TestEvent.ATTR, "test")).isNotEmpty());
+        assertTrue(coll.retrieve(equal(TestEvent.ATTR_DEP, "test")).isNotEmpty());
         assertTrue(coll.retrieve(contains(TestEvent.ATTR, "es")).isNotEmpty());
         assertEquals(coll.retrieve(equal(TestEvent.ATTR, "test")).uniqueResult().get().string(), "test");
         assertEquals(coll.retrieve(equal(TestEvent.ATTRS, "test")).uniqueResult().get().string(), "test");
@@ -612,7 +617,7 @@ public abstract class RepositoryTest<T extends Repository> {
         private final Optional<String> optional;
 
         @Index({EQ, UNIQUE})
-        public static SimpleIndex<TestOptionalEvent, UUID> ATTR = StandardEntity::uuid;
+        public final static SimpleIndex<TestOptionalEvent, UUID> ATTR = SimpleIndex.as(StandardEntity::uuid);
 
         @Builder
         public TestOptionalEvent(Optional<String> optional) {
@@ -638,7 +643,7 @@ public abstract class RepositoryTest<T extends Repository> {
         }
 
         @Index({EQ, UNIQUE})
-        public static SimpleIndex<TestOptionalCommand, UUID> ATTR = StandardEntity::uuid;
+        public final static SimpleIndex<TestOptionalCommand, UUID> ATTR = SimpleIndex.as(StandardEntity::uuid);
 
     }
 

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/AddressChanged.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/AddressChanged.java
@@ -38,34 +38,30 @@ public class AddressChanged extends StandardEvent {
         return geoLocation.boundingCoordinates(distance, EARTH_RADIUS_KM);
     }
 
-    @NonFinal
-    public static SimpleIndex<AddressChanged, UUID> ID = StandardEntity::uuid;
 
-    @NonFinal
-    public static SimpleIndex<AddressChanged, UUID> REFERENCE_ID = AddressChanged::reference;
+    public final static SimpleIndex<AddressChanged, UUID> ID = SimpleIndex.as(StandardEntity::uuid);
 
-    @NonFinal
+
+    public final static SimpleIndex<AddressChanged, UUID> REFERENCE_ID = SimpleIndex.as(AddressChanged::reference);
+
+
     @Index({EQ, LT, GT})
-    public static SimpleIndex<AddressChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
+    public final static SimpleIndex<AddressChanged, HybridTimestamp> TIMESTAMP = SimpleIndex.as(StandardEntity::timestamp);
 
-    @NonFinal
-    @Index({EQ, LT, GT})
-    public static SimpleIndex<AddressChanged, Double> BOUNDING_BOX_10K_LAT_START =
-            (addressChanged) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[0].getLatitudeInDegrees();
 
-    @NonFinal
     @Index({EQ, LT, GT})
-    public static SimpleIndex<AddressChanged, Double> BOUNDING_BOX_10K_LONG_START =
-            (addressChanged) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[0].getLongitudeInDegrees();
+    public final static SimpleIndex<AddressChanged, Double> BOUNDING_BOX_10K_LAT_START = SimpleIndex.as((addressChanged) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[0].getLatitudeInDegrees());
 
-    @NonFinal
-    @Index({EQ, LT, GT})
-    public static SimpleIndex<AddressChanged, Double> BOUNDING_BOX_10K_LAT_END =
-            (addressChanged) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[1].getLatitudeInDegrees();
 
-    @NonFinal
     @Index({EQ, LT, GT})
-    public static SimpleIndex<AddressChanged, Double> BOUNDING_BOX_10K_LONG_END =
-            (addressChanged) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[1].getLongitudeInDegrees();
+    public final static SimpleIndex<AddressChanged, Double> BOUNDING_BOX_10K_LONG_START = SimpleIndex.as((addressChanged) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[0].getLongitudeInDegrees());
+
+
+    @Index({EQ, LT, GT})
+    public final static SimpleIndex<AddressChanged, Double> BOUNDING_BOX_10K_LAT_END = SimpleIndex.as((addressChanged) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[1].getLatitudeInDegrees());
+
+
+    @Index({EQ, LT, GT})
+    public final static SimpleIndex<AddressChanged, Double> BOUNDING_BOX_10K_LONG_END = SimpleIndex.as((addressChanged) -> addressChanged.boundingCoordinates(DISTANCE_10_KM)[1].getLongitudeInDegrees());
 
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/MenuItemAdded.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/MenuItemAdded.java
@@ -24,9 +24,9 @@ public class MenuItemAdded extends StandardEvent {
 
     private UUID reference;
 
-    @NonFinal
-    public static SimpleIndex<MenuItemAdded, UUID> ID = StandardEntity::uuid;
 
-    @NonFinal
-    public static SimpleIndex<MenuItemAdded, UUID> REFERENCE_ID = MenuItemAdded::reference;
+    public final static SimpleIndex<MenuItemAdded, UUID> ID = SimpleIndex.as(StandardEntity::uuid);
+
+
+    public final static SimpleIndex<MenuItemAdded, UUID> REFERENCE_ID = SimpleIndex.as(MenuItemAdded::reference);
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/OrderConfirmed.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/OrderConfirmed.java
@@ -20,6 +20,6 @@ import java.util.UUID;
 public class OrderConfirmed extends StandardEvent {
     UUID reference;
 
-    @NonFinal
-    public static SimpleIndex<OrderConfirmed, UUID> REFERENCE = OrderConfirmed::reference;
+
+    public final static SimpleIndex<OrderConfirmed, UUID> REFERENCE = SimpleIndex.as(OrderConfirmed::reference);
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/OrderPlaced.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/OrderPlaced.java
@@ -14,7 +14,6 @@ import com.eventsourcing.index.SimpleIndex;
 import foodsourcing.Order;
 import lombok.Value;
 import lombok.experimental.Accessors;
-import lombok.experimental.NonFinal;
 
 import java.util.List;
 import java.util.UUID;
@@ -25,11 +24,11 @@ import java.util.stream.Collectors;
 public class OrderPlaced extends StandardEvent {
     private List<Order.Item> items;
 
-    @NonFinal
-    public static SimpleIndex<OrderPlaced, UUID> ID = StandardEntity::uuid;
 
-    @NonFinal
-    public static MultiValueIndex<OrderPlaced, UUID> ITEM =
-            (object) -> object.items().stream().map(Order.Item::menuItem)
-                              .collect(Collectors.toList());
+    public final static SimpleIndex<OrderPlaced, UUID> ID = SimpleIndex.as(StandardEntity::uuid);
+
+
+    public final static MultiValueIndex<OrderPlaced, UUID> ITEM =
+            MultiValueIndex.as((object) -> object.items().stream().map(Order.Item::menuItem)
+                              .collect(Collectors.toList()));
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/PaymentCaptured.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/PaymentCaptured.java
@@ -22,9 +22,9 @@ public class PaymentCaptured extends StandardEvent {
     UUID reference;
     BigDecimal amount;
 
-    @NonFinal
-    public static SimpleIndex<PaymentCaptured, UUID> REFERENCE = PaymentCaptured::reference;
 
-    @NonFinal
-    public static SimpleIndex<PaymentCaptured, BigDecimal> AMOUNT = PaymentCaptured::amount;
+    public final static SimpleIndex<PaymentCaptured, UUID> REFERENCE = SimpleIndex.as(PaymentCaptured::reference);
+
+
+    public final static SimpleIndex<PaymentCaptured, BigDecimal> AMOUNT = SimpleIndex.as(PaymentCaptured::amount);
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/PictureChanged.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/PictureChanged.java
@@ -30,10 +30,10 @@ public class PictureChanged extends StandardEvent implements Picture {
     private String contentType;
     private byte[] picture;
 
-    @NonFinal
-    public static SimpleIndex<PictureChanged, UUID> REFERENCE_ID = PictureChanged::reference;
 
-    @NonFinal
+    public final static SimpleIndex<PictureChanged, UUID> REFERENCE_ID = SimpleIndex.as(PictureChanged::reference);
+
+
     @Index({EQ, LT, GT})
-    public static SimpleIndex<PictureChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
+    public final static SimpleIndex<PictureChanged, HybridTimestamp> TIMESTAMP = SimpleIndex.as(StandardEntity::timestamp);
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/PriceChanged.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/PriceChanged.java
@@ -29,11 +29,11 @@ public class PriceChanged extends StandardEvent {
     private UUID reference;
     private BigDecimal price;
 
-    @NonFinal
-    public static SimpleIndex<PriceChanged, UUID> REFERENCE_ID = PriceChanged::reference;
 
-    @NonFinal
+    public final static SimpleIndex<PriceChanged, UUID> REFERENCE_ID = SimpleIndex.as(PriceChanged::reference);
+
+
     @Index({EQ, LT, GT})
-    public static SimpleIndex<PriceChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
+    public final static SimpleIndex<PriceChanged, HybridTimestamp> TIMESTAMP = SimpleIndex.as(StandardEntity::timestamp);
 
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/RestaurantRegistered.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/RestaurantRegistered.java
@@ -15,6 +15,6 @@ import java.util.UUID;
 
 public class RestaurantRegistered extends StandardEvent {
 
-    public static SimpleIndex<RestaurantRegistered, UUID> ID = StandardEntity::uuid;
+    public final static SimpleIndex<RestaurantRegistered, UUID> ID = SimpleIndex.as(StandardEntity::uuid);
 
 }

--- a/examples/foodsourcing/src/main/java/foodsourcing/events/WorkingHoursChanged.java
+++ b/examples/foodsourcing/src/main/java/foodsourcing/events/WorkingHoursChanged.java
@@ -35,12 +35,12 @@ public class WorkingHoursChanged extends StandardEvent {
     private DayOfWeek dayOfWeek;
     private List<OpeningHours> openDuring;
 
-    @NonFinal
-    public static SimpleIndex<WorkingHoursChanged, UUID> REFERENCE_ID = WorkingHoursChanged::reference;
 
-    @NonFinal
+    public final static SimpleIndex<WorkingHoursChanged, UUID> REFERENCE_ID = SimpleIndex.as(WorkingHoursChanged::reference);
+
+
     @Index({EQ, LT, GT})
-    public static SimpleIndex<WorkingHoursChanged, HybridTimestamp> TIMESTAMP = StandardEntity::timestamp;
+    public final static SimpleIndex<WorkingHoursChanged, HybridTimestamp> TIMESTAMP = SimpleIndex.as(StandardEntity::timestamp);
 
     @Value
     public static class OpeningHoursBoundary
@@ -74,24 +74,24 @@ public class WorkingHoursChanged extends StandardEvent {
         }
     }
 
-    @NonFinal
+
     @Index({EQ, LT, GT})
-    public static MultiValueIndex<WorkingHoursChanged, OpeningHoursBoundary> OPENING_AT =
-            (workingHoursChanged) ->
+    public final static MultiValueIndex<WorkingHoursChanged, OpeningHoursBoundary> OPENING_AT =
+            MultiValueIndex.as((workingHoursChanged) ->
                     workingHoursChanged.openDuring().stream()
                             .map(openingHours ->
                                               new OpeningHoursBoundary(workingHoursChanged.dayOfWeek(), openingHours.from()))
-                            .collect(Collectors.toList());
+                            .collect(Collectors.toList()));
 
-    @NonFinal
+
     @Index({EQ, LT, GT})
-    public static MultiValueIndex<WorkingHoursChanged, OpeningHoursBoundary> CLOSING_AT =
-            (workingHoursChanged) ->
+    public final static MultiValueIndex<WorkingHoursChanged, OpeningHoursBoundary> CLOSING_AT =
+            MultiValueIndex.as((workingHoursChanged) ->
                     workingHoursChanged.openDuring().stream()
                                  .map(openingHours ->
                                               new OpeningHoursBoundary(workingHoursChanged.dayOfWeek(), openingHours.till()))
-                                 .collect(Collectors.toList());
-    @NonFinal
-    public static SimpleIndex<WorkingHoursChanged, DayOfWeek> DAY_OF_WEEK = WorkingHoursChanged::dayOfWeek;
+                                 .collect(Collectors.toList()));
+
+    public final static SimpleIndex<WorkingHoursChanged, DayOfWeek> DAY_OF_WEEK = SimpleIndex.as(WorkingHoursChanged::dayOfWeek);
 
 }


### PR DESCRIPTION
Generally speaking, modifying a static field is a code smell.

The values are not getting cached, and it doesn't work well
with defaults Lombok does for value classes (final statics)

Solution: deprecate existing index definition syntax
and introduce a new one

The new **proposed** syntax is:

```java
public static final SimpleIndex<MyEvent, UUID> ID = SimpleIndex.as(StandardEntity::uuid);
public static final MultiValueIndex<MyEvent, String> VALS = MultiValueIndex.as(MyEvent::vals);
```

This way, at the expense of a slightly more verbose index,
we're allowing to make index statics final.

*Any thoughts?*

(Thanks to @sebastianharko for nudging me)