### PR TITLE
Problem: using postgresql backend without a pool is nearly impossible

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/CascadingIndexEngine.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/CascadingIndexEngine.java
@@ -94,11 +94,13 @@ public class CascadingIndexEngine extends CQIndexEngine implements IndexEngine, 
     @Override
     public void setJournal(Journal journal) throws IllegalStateException {
         this.journal = journal;
+        indexEngines.forEach(indexEngine -> indexEngine.setJournal(journal));
     }
 
     @Override
     public void setRepository(Repository repository) throws IllegalStateException {
         this.repository = repository;
+        indexEngines.forEach(indexEngine -> indexEngine.setRepository(repository));
     }
 
     private Map<String, IndexEngine> decisions = new HashMap<>();

--- a/eventsourcing-postgresql/build.gradle
+++ b/eventsourcing-postgresql/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     testCompile project(':eventsourcing-repository').sourceSets.test.output
 
     compile 'com.eventsourcing:pgjdbc-ng:0.7.0-7d96678'
+    compile 'com.zaxxer:HikariCP:2.5.1'
 
     // Embedded PostgreSQL for testing
     testCompile 'ru.yandex.qatools.embed:postgresql-embedded:1.15'

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/DataSourceProvider.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/DataSourceProvider.java
@@ -7,8 +7,8 @@
  */
 package com.eventsourcing.postgresql;
 
-import javax.sql.DataSource;
+import com.impossibl.postgres.jdbc.PGDataSource;
 
 public interface DataSourceProvider {
-    DataSource getDataSource();
+    PGDataSource getDataSource();
 }

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/PooledDataSource.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/PooledDataSource.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.postgresql;
+
+import com.eventsourcing.Repository;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+class PooledDataSource {
+
+    private static Map<Repository, PooledDataSource> instance = new HashMap<>();
+
+    public static PooledDataSource getInstance(Repository repository) {
+        return instance.computeIfAbsent(repository, (r) -> new PooledDataSource());
+    }
+
+    @Getter @Setter
+    private DataSource dataSource;
+
+    @Getter @Setter
+    private HikariConfig hikariConfig = new HikariConfig();
+
+    public DataSource getDataSource() {
+        if (dataSource == null) {
+            dataSource = new HikariDataSource(hikariConfig);
+        }
+        return dataSource;
+    }
+
+}

--- a/eventsourcing-postgresql/src/test/java/com/eventsourcing/postgresql/PostgreSQLRepositoryTest.java
+++ b/eventsourcing-postgresql/src/test/java/com/eventsourcing/postgresql/PostgreSQLRepositoryTest.java
@@ -14,17 +14,16 @@ import com.eventsourcing.index.IndexEngine;
 import com.eventsourcing.index.MemoryIndexEngine;
 import com.eventsourcing.repository.RepositoryTest;
 import com.eventsourcing.repository.StandardRepository;
+import com.impossibl.postgres.jdbc.PGDataSource;
 import lombok.SneakyThrows;
 import org.testng.annotations.Test;
-
-import javax.sql.DataSource;
 
 import static com.eventsourcing.postgresql.PostgreSQLTest.createDataSource;
 
 @Test
 public class PostgreSQLRepositoryTest extends RepositoryTest<Repository> {
 
-    private DataSource dataSource;
+    private PGDataSource dataSource;
 
     public PostgreSQLRepositoryTest() throws Exception {
         super(new StandardRepository());

--- a/eventsourcing-postgresql/src/test/java/com/eventsourcing/postgresql/PostgreSQLTest.java
+++ b/eventsourcing-postgresql/src/test/java/com/eventsourcing/postgresql/PostgreSQLTest.java
@@ -19,7 +19,7 @@ import javax.sql.DataSource;
 public abstract class PostgreSQLTest {
 
     @SneakyThrows
-    public static DataSource createDataSource() {
+    public static PGDataSource createDataSource() {
         PostgresStarter<PostgresExecutable, PostgresProcess> runtime = PostgresStarter.getDefaultInstance();
         final PostgresConfig pgConfig = PostgresConfig.defaultWithDbName("eventsourcing",
                                                                          "eventsourcing", "eventsourcing");

--- a/src/jmh/java/com/eventsourcing/jmh/PostgreSQLJournalBenchmark.java
+++ b/src/jmh/java/com/eventsourcing/jmh/PostgreSQLJournalBenchmark.java
@@ -25,8 +25,7 @@ public class PostgreSQLJournalBenchmark extends JournalBenchmark {
 
         HikariConfig config = new HikariConfig();
         config.setMaximumPoolSize(30);
-        config.setDataSource(ds);
 
-        return new PostgreSQLJournal(new HikariDataSource(config));
+        return new PostgreSQLJournal(ds, config);
     }
 }

--- a/src/jmh/java/com/eventsourcing/jmh/PostgreSQLRepositoryBenchmark.java
+++ b/src/jmh/java/com/eventsourcing/jmh/PostgreSQLRepositoryBenchmark.java
@@ -31,9 +31,8 @@ public class PostgreSQLRepositoryBenchmark extends RepositoryBenchmark {
 
         HikariConfig config = new HikariConfig();
         config.setMaximumPoolSize(30);
-        config.setDataSource(ds);
 
-        return new PostgreSQLJournal(new HikariDataSource(config));
+        return new PostgreSQLJournal(ds, config);
     }
 
 


### PR DESCRIPTION
It's just too slow because it'll keep re-opening connections and re-scanning
types.

Solution: enforce pgjdbc-ng and make use of HikariCP underneath

Fixes #184