### PR TITLE
Problem: re-indexing upon index init causes N entity pgsql queries

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/Journal.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/Journal.java
@@ -8,13 +8,13 @@
 package com.eventsourcing;
 
 import com.eventsourcing.hlc.HybridTimestamp;
+import com.eventsourcing.utils.CloseableWrappingIterator;
+import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.Service;
 import com.googlecode.cqengine.index.support.CloseableIterator;
 import lombok.SneakyThrows;
 
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -59,7 +59,9 @@ public interface Journal extends Service {
      * @param <T>
      * @return iterator
      */
-    <T extends Command<?, ?>> CloseableIterator<EntityHandle<T>> commandIterator(Class<T> klass);
+    default <T extends Command<?, ?>> CloseableIterator<EntityHandle<T>> commandIterator(Class<T> klass) {
+        return new CloseableWrappingIterator<>(Collections.emptyIterator());
+    }
 
     /**
      * Iterate over events of a specific type (through {@code EntityHandler<T>})
@@ -68,7 +70,32 @@ public interface Journal extends Service {
      * @param <T>
      * @return iterator
      */
-    <T extends Event> CloseableIterator<EntityHandle<T>> eventIterator(Class<T> klass);
+    default <T extends Event> CloseableIterator<EntityHandle<T>> eventIterator(Class<T> klass) {
+        return new CloseableWrappingIterator<>(Collections.emptyIterator());
+    }
+
+    /**
+     * Iterate over commands of a specific type (through {@code EntityHandler<T>})
+     *
+     * @param klass
+     * @param <T>
+     * @return iterator
+     */
+    default <T extends Command<?, ?>> CloseableIterator<EntityHandle<T>> commandIterator(Class<T> klass, boolean
+            eagerFetching) {
+        return commandIterator(klass);
+    }
+
+    /**
+     * Iterate over events of a specific type (through {@code EntityHandler<T>})
+     *
+     * @param klass
+     * @param <T>
+     * @return iterator
+     */
+    default <T extends Event> CloseableIterator<EntityHandle<T>> eventIterator(Class<T> klass, boolean eagerFetching) {
+        return eventIterator(klass);
+    }
 
     /**
      * Removes everything from the journal.

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/CommandJournalPersistence.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/CommandJournalPersistence.java
@@ -48,7 +48,7 @@ public class CommandJournalPersistence<T extends Command<?, ?>> extends JournalP
 
         @Override
         public CloseableIterator<EntityHandle<T>> iterator(QueryOptions queryOptions) {
-            return journal.commandIterator(klass);
+            return journal.commandIterator(klass, queryOptions.get(EagerFetching.class) != null);
         }
     }
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/EagerFetching.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/EagerFetching.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.index;
+
+import com.googlecode.cqengine.query.option.QueryOptions;
+
+/**
+ * EagerFetching is a {@link QueryOptions} query option that signals to the indexing subsystem to eagerly fetch entities
+ * if possible. Useful when iterating over the entire journal and processing the entire batch.
+ */
+public final class EagerFetching {
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/EventJournalPersistence.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/EventJournalPersistence.java
@@ -49,7 +49,7 @@ public class EventJournalPersistence<T extends Event> extends JournalPersistence
 
         @Override
         public CloseableIterator<EntityHandle<T>> iterator(QueryOptions queryOptions) {
-            return journal.eventIterator(klass);
+            return journal.eventIterator(klass, queryOptions.get(EagerFetching.class) != null);
         }
     }
 }

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/PostgreSQLAttributeIndex.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/PostgreSQLAttributeIndex.java
@@ -10,10 +10,8 @@ package com.eventsourcing.postgresql.index;
 import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
 import com.eventsourcing.ResolvedEntityHandle;
+import com.eventsourcing.index.*;
 import com.eventsourcing.index.AbstractAttributeIndex;
-import com.eventsourcing.index.Attribute;
-import com.eventsourcing.index.KeyObjectStore;
-import com.eventsourcing.index.MultiValueAttribute;
 import com.eventsourcing.layout.Layout;
 import com.eventsourcing.layout.SerializableComparable;
 import com.eventsourcing.layout.TypeHandler;
@@ -273,6 +271,7 @@ public abstract class PostgreSQLAttributeIndex<A, O extends Entity> extends Abst
             this.keyObjectStore = new SetKeyObjectStore(objectStore, queryOptions);
         }
         queryOptions.put(OnConflictDo.class, OnConflictDo.NOTHING);
+        queryOptions.put(EagerFetching.class, true);
         addAll(objectStore, queryOptions);
     }
 


### PR DESCRIPTION
Because of the way PostgreSQL journal event/command iteration works,
for every index re-addition entry in the batch, a separate query will
be executed to fetch the actual entity, which is incredibly slow.

Solution: introduce `EagerFetching` query option that instructs to
pre-fetch the entitites.