### PR TITLE
Problem: MemoryIndexEngine is in eventsourcing-core

### DIFF
--- a/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/RepositoryUsingTest.java
+++ b/eventsourcing-cep/src/test/java/com/eventsourcing/cep/protocols/RepositoryUsingTest.java
@@ -12,7 +12,7 @@ import com.eventsourcing.PackageCommandSetProvider;
 import com.eventsourcing.PackageEventSetProvider;
 import com.eventsourcing.Repository;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
-import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.inmem.MemoryJournal;
 import com.eventsourcing.repository.StandardRepository;
 import org.testng.annotations.AfterMethod;

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/CascadingIndexEngineTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/CascadingIndexEngineTest.java
@@ -11,6 +11,7 @@ import com.eventsourcing.Journal;
 import com.eventsourcing.Repository;
 import com.eventsourcing.StandardEntity;
 import com.eventsourcing.hlc.HybridTimestamp;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.inmem.MemoryJournal;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.SneakyThrows;

--- a/eventsourcing-core/src/test/java/com/eventsourcing/index/EntityQueryFactoryTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/index/EntityQueryFactoryTest.java
@@ -10,6 +10,7 @@ package com.eventsourcing.index;
 import com.eventsourcing.*;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.inmem.MemoryJournal;
 import com.eventsourcing.repository.StandardRepository;
 import com.googlecode.cqengine.resultset.ResultSet;

--- a/eventsourcing-h2/build.gradle
+++ b/eventsourcing-h2/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     compile project(':eventsourcing-core')
 
     testCompile project(':eventsourcing-repository')
+    testCompile project(':eventsourcing-inmem')
     testCompile project(':eventsourcing-core').sourceSets.test.output
     testCompile project(':eventsourcing-repository').sourceSets.test.output
 

--- a/eventsourcing-h2/src/test/java/com/eventsourcing/h2/MVStoreJournalRepositoryTest.java
+++ b/eventsourcing-h2/src/test/java/com/eventsourcing/h2/MVStoreJournalRepositoryTest.java
@@ -10,7 +10,7 @@ package com.eventsourcing.h2;
 import com.eventsourcing.Journal;
 import com.eventsourcing.index.CascadingIndexEngine;
 import com.eventsourcing.index.IndexEngine;
-import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.repository.RepositoryTest;
 import com.eventsourcing.repository.StandardRepository;
 import org.h2.mvstore.MVStore;

--- a/eventsourcing-inmem/build.gradle
+++ b/eventsourcing-inmem/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     compile project(':eventsourcing-core')
 
+    testCompile project(':eventsourcing-core').sourceSets.test.output
     testCompile project(':eventsourcing-repository').sourceSets.test.output
     testCompile project(':eventsourcing-repository')
 

--- a/eventsourcing-inmem/src/main/java/com/eventsourcing/inmem/MemoryIndexEngine.java
+++ b/eventsourcing-inmem/src/main/java/com/eventsourcing/inmem/MemoryIndexEngine.java
@@ -5,12 +5,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.eventsourcing.index;
+package com.eventsourcing.inmem;
 
 import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
 import com.eventsourcing.Journal;
 import com.eventsourcing.Repository;
+import com.eventsourcing.index.CQIndexEngine;
+import com.eventsourcing.index.IndexEngine;
 import com.googlecode.cqengine.ConcurrentIndexedCollection;
 import com.googlecode.cqengine.IndexedCollection;
 import com.googlecode.cqengine.attribute.Attribute;

--- a/eventsourcing-inmem/src/test/java/com/eventsourcing/inmem/MemoryHashIndexTest.java
+++ b/eventsourcing-inmem/src/test/java/com/eventsourcing/inmem/MemoryHashIndexTest.java
@@ -5,14 +5,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.eventsourcing.index;
+package com.eventsourcing.inmem;
 
 import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
+import com.eventsourcing.index.Attribute;
+import com.eventsourcing.index.EqualityIndexTest;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.googlecode.cqengine.IndexedCollection;
 import com.googlecode.cqengine.index.hash.HashIndex;
 import com.googlecode.cqengine.persistence.onheap.OnHeapPersistence;
+import org.testng.annotations.Test;
 
+@Test
 public class MemoryHashIndexTest extends EqualityIndexTest<HashIndex> {
 
     @Override public <O extends Entity> IndexedCollection<EntityHandle<O>> createIndexedCollection(Class<O> klass) {

--- a/eventsourcing-inmem/src/test/java/com/eventsourcing/inmem/MemoryIndexEngineTest.java
+++ b/eventsourcing-inmem/src/test/java/com/eventsourcing/inmem/MemoryIndexEngineTest.java
@@ -5,8 +5,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.eventsourcing.index;
+package com.eventsourcing.inmem;
 
+import com.eventsourcing.index.IndexEngineTest;
+import com.eventsourcing.inmem.MemoryIndexEngine;
+import org.testng.annotations.Test;
+
+@Test
 public class MemoryIndexEngineTest extends IndexEngineTest<MemoryIndexEngine> {
     public MemoryIndexEngineTest() {
         super(new MemoryIndexEngine());

--- a/eventsourcing-inmem/src/test/java/com/eventsourcing/inmem/MemoryNavigableIndexTest.java
+++ b/eventsourcing-inmem/src/test/java/com/eventsourcing/inmem/MemoryNavigableIndexTest.java
@@ -5,10 +5,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.eventsourcing.index;
+package com.eventsourcing.inmem;
 
 import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
+import com.eventsourcing.index.Attribute;
+import com.eventsourcing.index.NavigableIndexTest;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.navigable.NavigableIndex;
 import com.googlecode.cqengine.quantizer.Quantizer;

--- a/eventsourcing-inmem/src/test/java/com/eventsourcing/inmem/MemoryUniqueIndexTest.java
+++ b/eventsourcing-inmem/src/test/java/com/eventsourcing/inmem/MemoryUniqueIndexTest.java
@@ -5,11 +5,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.eventsourcing.index;
+package com.eventsourcing.inmem;
 
 import com.eventsourcing.Entity;
+import com.eventsourcing.index.Attribute;
+import com.eventsourcing.index.UniqueIndexTest;
 import com.googlecode.cqengine.index.unique.UniqueIndex;
+import org.testng.annotations.Test;
 
+@Test
 public class MemoryUniqueIndexTest extends UniqueIndexTest<UniqueIndex> {
 
     @Override

--- a/eventsourcing-kotlin/build.gradle
+++ b/eventsourcing-kotlin/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     compile project(':eventsourcing-layout')
     compile project(':eventsourcing-core')
 
+    testCompile project(':eventsourcing-inmem')
+
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 

--- a/eventsourcing-kotlin/src/test/kotlin/EntityTest.kt
+++ b/eventsourcing-kotlin/src/test/kotlin/EntityTest.kt
@@ -8,7 +8,7 @@
 
 import com.eventsourcing.StandardEvent
 import com.eventsourcing.index.JavaStaticFieldIndexLoader
-import com.eventsourcing.index.MemoryIndexEngine
+import com.eventsourcing.inmem.MemoryIndexEngine
 import com.eventsourcing.index.SimpleIndex
 import org.testng.annotations.Test
 import kotlin.test.assertTrue

--- a/eventsourcing-migrations/src/test/java/com/eventsourcing/migrations/RepositoryTest.java
+++ b/eventsourcing-migrations/src/test/java/com/eventsourcing/migrations/RepositoryTest.java
@@ -12,7 +12,7 @@ import com.eventsourcing.PackageCommandSetProvider;
 import com.eventsourcing.PackageEventSetProvider;
 import com.eventsourcing.Repository;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
-import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.inmem.MemoryJournal;
 import com.eventsourcing.repository.StandardRepository;
 import org.testng.annotations.AfterMethod;

--- a/eventsourcing-postgresql/src/test/java/com/eventsourcing/postgresql/PostgreSQLRepositoryTest.java
+++ b/eventsourcing-postgresql/src/test/java/com/eventsourcing/postgresql/PostgreSQLRepositoryTest.java
@@ -11,7 +11,7 @@ import com.eventsourcing.Journal;
 import com.eventsourcing.Repository;
 import com.eventsourcing.index.CascadingIndexEngine;
 import com.eventsourcing.index.IndexEngine;
-import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.repository.RepositoryTest;
 import com.eventsourcing.repository.StandardRepository;
 import com.impossibl.postgres.jdbc.PGDataSource;

--- a/eventsourcing-queries/src/test/java/com/eventsourcing/queries/RepositoryUsingTest.java
+++ b/eventsourcing-queries/src/test/java/com/eventsourcing/queries/RepositoryUsingTest.java
@@ -12,7 +12,7 @@ import com.eventsourcing.PackageCommandSetProvider;
 import com.eventsourcing.PackageEventSetProvider;
 import com.eventsourcing.Repository;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
-import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.inmem.MemoryJournal;
 import com.eventsourcing.repository.StandardRepository;
 import org.testng.annotations.AfterMethod;

--- a/eventsourcing-repository/src/main/java/com/eventsourcing/repository/QuerySubscriber.java
+++ b/eventsourcing-repository/src/main/java/com/eventsourcing/repository/QuerySubscriber.java
@@ -13,7 +13,7 @@ import com.eventsourcing.EntitySubscriber;
 import com.eventsourcing.Repository;
 import com.eventsourcing.index.IndexEngine;
 import com.eventsourcing.index.IndexLoader;
-import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.googlecode.cqengine.IndexedCollection;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.query.Query;

--- a/eventsourcing-repository/src/test/java/com/eventsourcing/repository/JournalTest.java
+++ b/eventsourcing-repository/src/test/java/com/eventsourcing/repository/JournalTest.java
@@ -12,7 +12,7 @@ import com.eventsourcing.events.EventCausalityEstablished;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.index.IndexEngine;
-import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.googlecode.cqengine.index.support.CloseableIterator;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/eventsourcing-repository/src/test/java/com/eventsourcing/repository/RepositoryTest.java
+++ b/eventsourcing-repository/src/test/java/com/eventsourcing/repository/RepositoryTest.java
@@ -16,6 +16,7 @@ import com.eventsourcing.events.JavaExceptionOccurred;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.index.*;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.layout.LayoutConstructor;
 import com.eventsourcing.migrations.events.EntityLayoutIntroduced;
 import com.eventsourcing.repository.commands.IntroduceEntityLayouts;

--- a/eventsourcing-repository/src/test/java/com/eventsourcing/repository/RepositoryUsingTest.java
+++ b/eventsourcing-repository/src/test/java/com/eventsourcing/repository/RepositoryUsingTest.java
@@ -12,7 +12,7 @@ import com.eventsourcing.PackageCommandSetProvider;
 import com.eventsourcing.PackageEventSetProvider;
 import com.eventsourcing.Repository;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
-import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.inmem.MemoryJournal;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;

--- a/examples/foodsourcing/src/test/java/foodsourcing/TestWithRepository.java
+++ b/examples/foodsourcing/src/test/java/foodsourcing/TestWithRepository.java
@@ -12,7 +12,7 @@ import com.eventsourcing.cep.events.Deleted;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.index.CascadingIndexEngine;
 import com.eventsourcing.index.IndexEngine;
-import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.inmem.MemoryJournal;
 import com.eventsourcing.postgresql.PostgreSQLIndexEngine;
 import com.eventsourcing.postgresql.PostgreSQLJournal;

--- a/src/jmh/java/com/eventsourcing/jmh/JournalBenchmark.java
+++ b/src/jmh/java/com/eventsourcing/jmh/JournalBenchmark.java
@@ -11,7 +11,7 @@ import com.eventsourcing.*;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.index.IndexEngine;
-import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.repository.StandardRepository;
 import lombok.SneakyThrows;
 import org.openjdk.jmh.annotations.*;

--- a/src/jmh/java/com/eventsourcing/jmh/MemoryRepositoryBenchmark.java
+++ b/src/jmh/java/com/eventsourcing/jmh/MemoryRepositoryBenchmark.java
@@ -9,7 +9,7 @@ package com.eventsourcing.jmh;
 
 import com.eventsourcing.Journal;
 import com.eventsourcing.index.IndexEngine;
-import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.inmem.MemoryJournal;
 
 public class MemoryRepositoryBenchmark extends RepositoryBenchmark {

--- a/src/jmh/java/com/eventsourcing/jmh/PostgreSQLRepositoryBenchmark.java
+++ b/src/jmh/java/com/eventsourcing/jmh/PostgreSQLRepositoryBenchmark.java
@@ -9,11 +9,10 @@ package com.eventsourcing.jmh;
 
 import com.eventsourcing.Journal;
 import com.eventsourcing.index.IndexEngine;
-import com.eventsourcing.index.MemoryIndexEngine;
+import com.eventsourcing.inmem.MemoryIndexEngine;
 import com.eventsourcing.postgresql.PostgreSQLJournal;
 import com.impossibl.postgres.jdbc.PGDataSource;
 import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
 
 public class PostgreSQLRepositoryBenchmark extends RepositoryBenchmark {
     @Override protected IndexEngine createIndex() {


### PR DESCRIPTION
This violates the separation of backends in their own individual
modules.

Solution: move it to eventsourcing-inmem