### PR TITLE
Problem: a Layout-related exception is missing a space character

### DIFF
--- a/eventsourcing-layout/src/main/java/com/eventsourcing/layout/Layout.java
+++ b/eventsourcing-layout/src/main/java/com/eventsourcing/layout/Layout.java
@@ -187,7 +187,7 @@ public class Layout<T> {
         }
 
         if (ambiguityDetected) {
-            throw new IllegalArgumentException(klass + "has more than one constructor with " +
+            throw new IllegalArgumentException(klass + " has more than one constructor with " +
                                                constructor.getParameters().length +
                                                " parameters and no @LayoutConstructor-annotated constructor");
         }


### PR DESCRIPTION
It results in exceptions like: "com.foo.Barhas more than one constructor with 2
parameters and no @LayoutConstructor-annotated constructor"

Solution: add the missing space