### PR TITLE
Problem: HybridTimestamp Comparable Serializable isn't correct

### DIFF
--- a/eventsourcing-hlc/build.gradle
+++ b/eventsourcing-hlc/build.gradle
@@ -7,4 +7,6 @@ dependencies {
 
     compile project(':eventsourcing-layout')
 
+    testCompile 'com.pholser:junit-quickcheck:0.7'
+    testCompile 'com.pholser:junit-quickcheck-generators:0.7'
 }

--- a/eventsourcing-hlc/src/main/java/com/eventsourcing/hlc/HybridTimestamp.java
+++ b/eventsourcing-hlc/src/main/java/com/eventsourcing/hlc/HybridTimestamp.java
@@ -13,6 +13,7 @@ import com.eventsourcing.layout.SerializableComparable;
 import lombok.Getter;
 import org.apache.commons.net.ntp.TimeStamp;
 
+import java.math.BigInteger;
 import java.util.Date;
 
 /**
@@ -20,7 +21,7 @@ import java.util.Date;
  * currently heavily inspired by a corresponding <a href="https://github.com/tschottdorf/hlc-rs">Rust library</a>.
  */
 @LayoutName("rfc.eventsourcing.com/spec:6/HLC/#Timestamp")
-public class HybridTimestamp implements Comparable<HybridTimestamp>, SerializableComparable<Long> {
+public class HybridTimestamp implements Comparable<HybridTimestamp>, SerializableComparable<BigInteger> {
 
     private final PhysicalTimeProvider physicalTimeProvider;
 
@@ -165,7 +166,11 @@ public class HybridTimestamp implements Comparable<HybridTimestamp>, Serializabl
                 () + ">";
     }
 
-    @Override public Long getSerializableComparable() {
-        return TimeStamp.getNtpTime(timestamp()).getDate().getTime();
+    @Override public BigInteger getSerializableComparable() {
+        TimeStamp t = new TimeStamp(logicalTime);
+        return BigInteger.valueOf(t.getSeconds())
+                         .shiftLeft(64)
+                         .add(BigInteger.valueOf(t.getFraction()).shiftLeft(32))
+                         .add(BigInteger.valueOf(logicalCounter));
     }
 }

--- a/eventsourcing-hlc/src/test/java/com/eventsourcing/hlc/SerializableComparableTest.java
+++ b/eventsourcing-hlc/src/test/java/com/eventsourcing/hlc/SerializableComparableTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.hlc;
+
+import com.google.common.base.Joiner;
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import lombok.SneakyThrows;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.testng.annotations.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(JUnitQuickcheck.class)
+public class SerializableComparableTest {
+
+    @Property(trials = 1_000)
+    public void test(long logicalTime, long logicalCounter, long logicalTime1, long logicalCounter1) {
+        HybridTimestamp ts1 = new HybridTimestamp(logicalTime, logicalCounter);
+        HybridTimestamp ts2 = new HybridTimestamp(logicalTime1, logicalCounter1);
+        assertEquals(ts1.compareTo(ts2), ts1.getSerializableComparable().compareTo(ts2.getSerializableComparable()));
+    }
+
+    @Test
+    @SneakyThrows
+    public void run() {
+        JUnitCore junit = new JUnitCore();
+        Result result = junit.run(SerializableComparableTest.class);
+        if (!result.wasSuccessful()) {
+            fail(Joiner.on("\n").join(result.getFailures()));
+        }
+    }
+}


### PR DESCRIPTION
`getComparableSerializable().compareTo()` provably does not match the
results of `compareTo()` 100% of the time because it's converting the
timestamp to NTP, therefore reducing the precision.

Solution: switch from Long to BigInteger Comparable Serializable, pack
all data in a comparable order and test it with quickcheck.