### PR TITLE
Problem: postgresql-embedded is outdated

### DIFF
--- a/eventsourcing-postgresql/build.gradle
+++ b/eventsourcing-postgresql/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     compile 'com.zaxxer:HikariCP:2.5.1'
 
     // Embedded PostgreSQL for testing
-    testCompile 'ru.yandex.qatools.embed:postgresql-embedded:1.15'
+    testCompile 'ru.yandex.qatools.embed:postgresql-embedded:1.19'
 
 }


### PR DESCRIPTION
It doesn't have a reference to PostgreSQL 9.6

Solution: upgrade postgresql-embedded to 1.19