### PR TITLE
Problem: min/max queries (pgsql) fail on empty collections

### DIFF
--- a/eventsourcing-core/src/test/java/com/eventsourcing/queries/MinMaxTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/queries/MinMaxTest.java
@@ -26,6 +26,7 @@ import static com.eventsourcing.index.IndexEngine.IndexFeature.LT;
 import static com.eventsourcing.queries.QueryFactory.max;
 import static com.eventsourcing.queries.QueryFactory.min;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class MinMaxTest extends RepositoryUsingTest {
 
@@ -71,5 +72,16 @@ public class MinMaxTest extends RepositoryUsingTest {
         try (ResultSet<EntityHandle<TestEvent>> rs = repository.query(TestEvent.class, max(TestEvent.TIMESTAMP))) {
             assertEquals(rs.uniqueResult().get().timestamp(), ts3);
         }
+    }
+
+
+    @Test
+    @SneakyThrows
+    public void empty() {
+
+        try (ResultSet<EntityHandle<TestEvent>> rs = repository.query(TestEvent.class, min(TestEvent.TIMESTAMP))) {
+            assertTrue(rs.isEmpty());
+        }
+
     }
 }

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/NavigableIndex.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/NavigableIndex.java
@@ -400,6 +400,14 @@ public class NavigableIndex <A extends Comparable<A>, O extends Entity> extends 
                                 }
                             };
                             return new CloseableResultSet<>(rs, query, queryOptions);
+                        } else {
+                            ResultSet<EntityHandle<O>> rs = new MatchingResultSet<O, Min<O, A>>
+                                    (Collections.emptyIterator(), (Min<O, A>) query, queryOptions, 0) {
+                                @Override public int getRetrievalCost() {
+                                    return AGGREGATE_RETRIEVAL_COST;
+                                }
+                            };
+                            return new CloseableResultSet<>(rs, query, queryOptions);
                         }
                     }
                 }
@@ -422,8 +430,15 @@ public class NavigableIndex <A extends Comparable<A>, O extends Entity> extends 
                                 }
                             };
                             return new CloseableResultSet<>(rs, query, queryOptions);
-                        }
-                    }
+                        } else {
+                            ResultSet<EntityHandle<O>> rs = new MatchingResultSet<O, Max<O, A>>
+                                    (Collections.emptyIterator(), (Max<O, A>) query, queryOptions, 0) {
+                                @Override public int getRetrievalCost() {
+                                    return AGGREGATE_RETRIEVAL_COST;
+                                }
+                            };
+                            return new CloseableResultSet<>(rs, query, queryOptions);
+                        }                    }
                 }
             }
         }


### PR DESCRIPTION
```
Unsupported query: max("TIMESTAMP")
```

Solution: return an empty resultset if there are no items
in the collection