### PR TITLE
Problem: isLatestEntity still requires to pass the collection

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/queries/QueryFactory.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/queries/QueryFactory.java
@@ -1095,7 +1095,9 @@ public interface QueryFactory  {
      * @param timestampAttribute timestamp attribute
      * @param <O> entity type
      * @return a query
+     * @deprecated use {@link #isLatestEntity(Query, EntityIndex)}
      */
+    @Deprecated
     static <O extends Entity> Query<EntityHandle<O>>
     isLatestEntity(final IndexedCollection<EntityHandle<O>> collection,
                    final Query<EntityHandle<O>> query,
@@ -1110,12 +1112,40 @@ public interface QueryFactory  {
      * @param timestampAttribute timestamp attribute
      * @param <O> entity type
      * @return a query
+     * @deprecated use {@link #isLatestEntity(Function, EntityIndex)}
      */
+    @Deprecated
     static <O extends Entity> Query<EntityHandle<O>>
     isLatestEntity(final IndexedCollection<EntityHandle<O>> collection,
                    final Function<EntityHandle<O>, Query<EntityHandle<O>>> query,
                    final EntityIndex<O, HybridTimestamp> timestampAttribute) {
         return new IsLatestEntity<>(collection, query, timestampAttribute.getAttribute());
+    }
+
+    /**
+     * @see LatestAssociatedEntryQuery
+     * @param query query as is
+     * @param timestampAttribute timestamp attribute
+     * @param <O> entity type
+     * @return a query
+     */
+    static <O extends Entity> Query<EntityHandle<O>>
+    isLatestEntity(final Query<EntityHandle<O>> query,
+                   final EntityIndex<O, HybridTimestamp> timestampAttribute) {
+        return new IsLatestEntity<>(query, timestampAttribute.getAttribute());
+    }
+
+    /**
+     * @see LatestAssociatedEntryQuery
+     * @param query query returning function
+     * @param timestampAttribute timestamp attribute
+     * @param <O> entity type
+     * @return a query
+     */
+    static <O extends Entity> Query<EntityHandle<O>>
+    isLatestEntity(final Function<EntityHandle<O>, Query<EntityHandle<O>>> query,
+                   final EntityIndex<O, HybridTimestamp> timestampAttribute) {
+        return new IsLatestEntity<>(query, timestampAttribute.getAttribute());
     }
 
     /**

--- a/eventsourcing-core/src/test/java/com/eventsourcing/queries/IsLatestEntityTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/queries/IsLatestEntityTest.java
@@ -20,15 +20,14 @@ import lombok.EqualsAndHashCode;
 import lombok.SneakyThrows;
 import lombok.Value;
 import lombok.experimental.Accessors;
-import lombok.experimental.NonFinal;
 import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static com.eventsourcing.queries.QueryFactory.equal;
 import static com.eventsourcing.index.IndexEngine.IndexFeature.*;
+import static com.eventsourcing.queries.QueryFactory.equal;
 import static com.eventsourcing.queries.QueryFactory.isLatestEntity;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -75,9 +74,7 @@ public class IsLatestEntityTest extends RepositoryUsingTest {
     public void test() {
         UUID uuid = UUID.randomUUID();
         repository.publish(new TestCommand("test1", uuid)).get();
-        IndexedCollection<EntityHandle<TestEvent>> coll = repository.getIndexEngine().getIndexedCollection
-                (TestEvent.class);
-        Query<EntityHandle<TestEvent>> query = isLatestEntity(coll, equal(TestEvent.REFERENCE_ID, uuid),
+        Query<EntityHandle<TestEvent>> query = isLatestEntity(equal(TestEvent.REFERENCE_ID, uuid),
                                                               TestEvent.TIMESTAMP);
         try (ResultSet<EntityHandle<TestEvent>> resultSet = repository.query(TestEvent.class, query)) {
             assertEquals(resultSet.size(), 1);
@@ -96,10 +93,7 @@ public class IsLatestEntityTest extends RepositoryUsingTest {
         for (int i = 0; i < 10000; i++ ) {
             repository.publish(new TestCommand("test" + (i + 1), uuid)).get();
         }
-        IndexedCollection<EntityHandle<TestEvent>> coll = repository.getIndexEngine().getIndexedCollection
-                (TestEvent.class);
-
-        Query<EntityHandle<TestEvent>> query = isLatestEntity(coll, equal(TestEvent.REFERENCE_ID, uuid),
+        Query<EntityHandle<TestEvent>> query = isLatestEntity(equal(TestEvent.REFERENCE_ID, uuid),
                                                               TestEvent.TIMESTAMP);
         long t1 = System.nanoTime();
         try (ResultSet<EntityHandle<TestEvent>> resultSet = repository.query(TestEvent.class, query)) {
@@ -123,10 +117,7 @@ public class IsLatestEntityTest extends RepositoryUsingTest {
         repository.publish(new TestCommand("testN1", uuidN)).get();
         repository.publish(new TestCommand("testN2", uuidN)).get();
 
-        IndexedCollection<EntityHandle<TestEvent>> coll = repository.getIndexEngine().getIndexedCollection
-                (TestEvent.class);
-        Query<EntityHandle<TestEvent>> query = isLatestEntity(coll,
-                                                              (h) -> equal(TestEvent.REFERENCE_ID, h.get().reference()),
+        Query<EntityHandle<TestEvent>> query = isLatestEntity((h) -> equal(TestEvent.REFERENCE_ID, h.get().reference()),
                                                               TestEvent.TIMESTAMP);
         try (ResultSet<EntityHandle<TestEvent>> resultSet = repository.query(TestEvent.class, query)) {
             assertEquals(resultSet.size(), 2);


### PR DESCRIPTION
min/max queries recently introduced a new way to pass the collection
via query options.

Solution: deprecate collection-taking isLatestEntity and introduce
new versions that get the implied collection instead.