### PR TITLE
Problem: OSGiEntitiesProvider's results are not updated over time

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/OSGiEntitiesProvider.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/OSGiEntitiesProvider.java
@@ -7,10 +7,13 @@
  */
 package com.eventsourcing;
 
+import com.google.common.base.Joiner;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
-import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -28,16 +31,14 @@ import java.util.stream.Collectors;
  * Provides an event and command sets from OSGi bundles
  */
 @Component(immediate = true)
-public class OSGiEntitiesProvider implements CommandSetProvider, EventSetProvider {
+public class OSGiEntitiesProvider {
 
-    private List<Class<? extends Command>> commands = new ArrayList<>();
-    private List<Class<? extends Event>> events = new ArrayList<>();
-    private BundleTracker<Object> tracker;
+    private BundleTracker<Collection<ServiceRegistration>> tracker;
 
     @Activate
     protected void activate(ComponentContext context) {
         tracker = new BundleTracker<>(context.getBundleContext(), Bundle.ACTIVE,
-                                    new ScannerBundleTracker());
+                                    new ScannerBundleTracker(context.getBundleContext()));
         tracker.open();
     }
 
@@ -47,53 +48,89 @@ public class OSGiEntitiesProvider implements CommandSetProvider, EventSetProvide
     }
 
 
-    <T> List<Class<? extends T>> findSubTypesOf(Bundle bundle, Collection<Class<T>> superclasses) {
-        BundleWiring wiring = bundle.adapt(BundleWiring.class);
-        Collection<String> names = wiring
-                .listResources("/", "*", BundleWiring.LISTRESOURCES_RECURSE);
-        return names.stream().map(new Function<String, Class<?>>() {
-            @Override @SneakyThrows
-            public Class<?> apply(String name) {
-                String n = name.replaceAll("\\.class$", "").replace('/', '.');
-                try {
-                    return bundle.loadClass(n);
-                } catch (ClassNotFoundException | NoClassDefFoundError e) {
-                    return null;
+    private static class BundleCommandEventSetProvider implements CommandSetProvider, EventSetProvider {
+
+        private final List<Class<? extends Command>> commands;
+        private final List<Class<? extends Event>> events;
+
+        public BundleCommandEventSetProvider(Bundle bundle) {
+            commands = findSubTypesOf(bundle, Collections.singleton(Command.class));
+            events = findSubTypesOf(bundle, Collections.singleton(Event.class));
+        }
+
+        private <T> List<Class<? extends T>> findSubTypesOf(Bundle bundle, Collection<Class<T>> superclasses) {
+            BundleWiring wiring = bundle.adapt(BundleWiring.class);
+            Collection<String> names = wiring
+                    .listResources("/", "*", BundleWiring.LISTRESOURCES_RECURSE);
+            return names.stream().map(new Function<String, Class<?>>() {
+                @Override @SneakyThrows
+                public Class<?> apply(String name) {
+                    String n = name.replaceAll("\\.class$", "").replace('/', '.');
+                    try {
+                        return bundle.loadClass(n);
+                    } catch (ClassNotFoundException | NoClassDefFoundError e) {
+                        return null;
+                    }
                 }
+            }).filter(c -> c != null).filter(c -> superclasses.stream().anyMatch(sc -> sc.isAssignableFrom(c)))
+                        .filter(c -> !c.isInterface() && !Modifier.isAbstract(c.getModifiers()))
+                        .map((Function<Class<?>, Class<? extends T>>) aClass -> (Class<? extends T>) aClass)
+                        .collect(Collectors.toList());
+        }
+
+        @Override public Set<Class<? extends Event>> getEvents() {
+            return new HashSet<>(events);
+        }
+
+        @Override public Set<Class<? extends Command>> getCommands() {
+            return new HashSet<>(commands);
+        }
+    }
+
+    @Slf4j
+    private static class ScannerBundleTracker implements BundleTrackerCustomizer<Collection<ServiceRegistration>> {
+
+        private final BundleContext bundleContext;
+
+        public ScannerBundleTracker(BundleContext bundleContext) {
+            this.bundleContext = bundleContext;
+        }
+
+        @Override public Collection<ServiceRegistration> addingBundle(Bundle bundle, BundleEvent event) {
+            BundleCommandEventSetProvider bundleCommandEventSetProvider = new BundleCommandEventSetProvider(bundle);
+
+            ArrayList<ServiceRegistration> registrations = new ArrayList<>();
+            Hashtable<String, Object> properties = new Hashtable<>();
+            properties.put("bundle", bundle.getSymbolicName());
+            if (!bundleCommandEventSetProvider.getCommands().isEmpty()) {
+                properties.put("commands", Joiner.on(", ").join(
+                        bundleCommandEventSetProvider.getCommands().stream().map(Class::getName).collect(Collectors.toList())));
+                log.info("Registering a service for providing commands in {}", bundle.getSymbolicName());
+                registrations.add(bundleContext.registerService(CommandSetProvider.class, bundleCommandEventSetProvider,
+                                                           properties));
             }
-        }).filter(c -> c != null).filter(c -> superclasses.stream().anyMatch(sc -> sc.isAssignableFrom(c)))
-                    .filter(c -> !c.isInterface() && !Modifier.isAbstract(c.getModifiers()))
-                    .map((Function<Class<?>, Class<? extends T>>) aClass -> (Class<? extends T>) aClass)
-                    .collect(Collectors.toList());
-    }
-
-    @Override
-    public Set<Class<? extends Event>> getEvents() {
-        return new HashSet<>(events);
-    }
-
-    @Override public Set<Class<? extends Command>> getCommands() {
-        return new HashSet<>(commands);
-    }
-
-    private class ScannerBundleTracker implements BundleTrackerCustomizer<Object> {
-        @Override public Object addingBundle(Bundle bundle,
-                                             BundleEvent event) {
-            events.addAll(findSubTypesOf(bundle, Arrays.asList(Event.class)));
-            commands.addAll(findSubTypesOf(bundle, Arrays.asList(Command.class)));
-            return null;
+            if (!bundleCommandEventSetProvider.getEvents().isEmpty()) {
+                properties.put("events", Joiner.on(", ").join(
+                        bundleCommandEventSetProvider.getEvents().stream().map(Class::getName).collect(Collectors.toList())));
+                log.info("Registering a service for providing events in {}", bundle.getSymbolicName());
+                registrations.add(bundleContext.registerService(EventSetProvider.class, bundleCommandEventSetProvider,
+                                                                properties));
+            }
+            return registrations;
         }
 
         @Override
         public void modifiedBundle(Bundle bundle, BundleEvent event,
-                                   Object object) {
+                                   Collection<ServiceRegistration> registrations) {
         }
 
         @Override
         public void removedBundle(Bundle bundle, BundleEvent event,
-                                  Object object) {
-            events.removeAll(findSubTypesOf(bundle, Arrays.asList(Event.class)));
-            commands.removeAll(findSubTypesOf(bundle, Arrays.asList(Command.class)));
+                                  Collection<ServiceRegistration> registrations) {
+            if (!registrations.isEmpty()) {
+                log.info("Deregistering services for providing commands and events in {}", bundle.getSymbolicName());
+                registrations.forEach(ServiceRegistration::unregister);
+            }
         }
     }
 }


### PR DESCRIPTION
Since repository grabs the command / event set once, if new bundles are started
or existing ones are stopped, the changes in the command/event set can't be reflected.

Solution: make OSGiEntitiesProvider register per-bundle services when
the bundle is active.