### PR TITLE
Problem: Min/Max queries are global to the attribute

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/Repository.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/Repository.java
@@ -192,6 +192,7 @@ public interface Repository extends Service {
     default <E extends Entity> ResultSet<EntityHandle<E>> query(Class<E> klass, Query<EntityHandle<E>> query,
                                                                         QueryOptions queryOptions) {
         IndexedCollection<EntityHandle<E>> collection = getIndexEngine().getIndexedCollection(klass);
+        queryOptions.put(Iterable.class, collection);
         queryOptions.put(IndexedCollection.class, collection);
         return collection.retrieve(query, queryOptions);
     }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/queries/ComparingQuery.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/queries/ComparingQuery.java
@@ -10,11 +10,12 @@ package com.eventsourcing.queries;
 import com.eventsourcing.Entity;
 import com.eventsourcing.EntityHandle;
 import com.eventsourcing.index.EntityIndex;
-import com.googlecode.cqengine.IndexedCollection;
 import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.query.Query;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import com.googlecode.cqengine.query.simple.SimpleQuery;
+import lombok.Getter;
 
 import java.util.Iterator;
 
@@ -30,7 +31,7 @@ public abstract class ComparingQuery<O extends Entity, A extends Comparable<A>> 
 
     private void ensureTargetIsFound(Attribute<EntityHandle<O>, A> attribute, QueryOptions queryOptions) {
         if (target == null) {
-            IndexedCollection<EntityHandle<O>> collection = queryOptions.get(IndexedCollection.class);
+            Iterable<EntityHandle<O>> collection = queryOptions.get(Iterable.class);
             if (collection == null) {
                 throw new RuntimeException(
                         toString() + " has to be supported by the target index or queryOptions should" +
@@ -54,7 +55,6 @@ public abstract class ComparingQuery<O extends Entity, A extends Comparable<A>> 
     public ComparingQuery(EntityIndex<O, A> index) {
         super(index.getAttribute());
     }
-
 
     @Override
     protected boolean matchesNonSimpleAttribute(Attribute<EntityHandle<O>, A> attribute, EntityHandle<O> object,

--- a/eventsourcing-core/src/main/java/com/eventsourcing/queries/IsLatestEntity.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/queries/IsLatestEntity.java
@@ -43,8 +43,11 @@ import static com.googlecode.cqengine.query.QueryFactory.greaterThan;
  * @see QueryFactory#isLatestEntity(Function, EntityIndex)
  * @see QueryFactory#isLatestEntity(Query, EntityIndex)
  *
+ * @deprecated See {@link Max}
+ *
  * @param <O>
  */
+@Deprecated
 public class IsLatestEntity<O extends EntityHandle> extends SimpleQuery<O, HybridTimestamp> {
 
     private final IndexedCollection<O> collection;
@@ -145,7 +148,7 @@ public class IsLatestEntity<O extends EntityHandle> extends SimpleQuery<O, Hybri
             return terminatedQuery.get();
         }
         HybridTimestamp value = attribute.getValue(object, queryOptions);
-        IndexedCollection<O> collection = getCollection(queryOptions);
+        IndexedCollection<O> collection = (IndexedCollection<O>) getCollection(queryOptions);
         try (ResultSet<O> resultSet = collection.retrieve(and(
                 actualQuery,
                 greaterThan(timestampAttribute, value)))) {
@@ -153,8 +156,8 @@ public class IsLatestEntity<O extends EntityHandle> extends SimpleQuery<O, Hybri
         }
     }
 
-    private IndexedCollection<O> getCollection(QueryOptions queryOptions) {
-        return this.collection == null ? queryOptions.get(IndexedCollection.class) : this
+    private Iterable<O> getCollection(QueryOptions queryOptions) {
+        return this.collection == null ? queryOptions.get(Iterable.class) : this
                 .collection;
     }
 
@@ -171,7 +174,7 @@ public class IsLatestEntity<O extends EntityHandle> extends SimpleQuery<O, Hybri
                                                  .map(v -> greaterThan(timestampAttribute, v))
                                                  .collect(Collectors.toList());
         Query<O> timestampQuery = conditions.size() == 1 ? conditions.get(0) : new Or<>(conditions);
-        IndexedCollection<O> collection = getCollection(queryOptions);
+        IndexedCollection<O> collection = (IndexedCollection<O>) getCollection(queryOptions);
         try (ResultSet<O> resultSet = collection.retrieve(and(
                 actualQuery,
                 timestampQuery))) {

--- a/eventsourcing-core/src/main/java/com/eventsourcing/queries/Max.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/queries/Max.java
@@ -9,7 +9,9 @@ package com.eventsourcing.queries;
 
 
 import com.eventsourcing.Entity;
+import com.eventsourcing.EntityHandle;
 import com.eventsourcing.index.EntityIndex;
+import com.googlecode.cqengine.query.Query;
 
 public class Max<O extends Entity, A extends Comparable<A>> extends ComparingQuery<O, A>  {
 

--- a/eventsourcing-core/src/main/java/com/eventsourcing/queries/Min.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/queries/Min.java
@@ -14,6 +14,7 @@ import com.eventsourcing.index.EntityIndex;
 import com.googlecode.cqengine.IndexedCollection;
 import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.query.Query;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import com.googlecode.cqengine.query.simple.SimpleQuery;
 

--- a/eventsourcing-core/src/main/java/com/eventsourcing/queries/QueryFactory.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/queries/QueryFactory.java
@@ -1095,7 +1095,7 @@ public interface QueryFactory  {
      * @param timestampAttribute timestamp attribute
      * @param <O> entity type
      * @return a query
-     * @deprecated use {@link #isLatestEntity(Query, EntityIndex)}
+     * @deprecated See {@link #max(EntityIndex)}
      */
     @Deprecated
     static <O extends Entity> Query<EntityHandle<O>>
@@ -1112,7 +1112,7 @@ public interface QueryFactory  {
      * @param timestampAttribute timestamp attribute
      * @param <O> entity type
      * @return a query
-     * @deprecated use {@link #isLatestEntity(Function, EntityIndex)}
+     * @deprecated See {@link #max(EntityIndex)}
      */
     @Deprecated
     static <O extends Entity> Query<EntityHandle<O>>
@@ -1128,7 +1128,9 @@ public interface QueryFactory  {
      * @param timestampAttribute timestamp attribute
      * @param <O> entity type
      * @return a query
+     * @deprecated See {@link #max(EntityIndex)}
      */
+    @Deprecated
     static <O extends Entity> Query<EntityHandle<O>>
     isLatestEntity(final Query<EntityHandle<O>> query,
                    final EntityIndex<O, HybridTimestamp> timestampAttribute) {
@@ -1141,7 +1143,9 @@ public interface QueryFactory  {
      * @param timestampAttribute timestamp attribute
      * @param <O> entity type
      * @return a query
+     * @deprecated See {@link #max(EntityIndex)}
      */
+    @Deprecated
     static <O extends Entity> Query<EntityHandle<O>>
     isLatestEntity(final Function<EntityHandle<O>, Query<EntityHandle<O>>> query,
                    final EntityIndex<O, HybridTimestamp> timestampAttribute) {
@@ -1168,5 +1172,10 @@ public interface QueryFactory  {
      */
     static <O extends Entity, A extends Comparable<A>> Max<O, A> max(EntityIndex<O, A> entityIndex) {
         return new Max<>(entityIndex);
+    }
+
+
+    static <O extends Entity> Scoped<O> scoped(Query<EntityHandle<O>> scope, Query<EntityHandle<O>> query) {
+        return new Scoped<>(scope, query);
     }
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/queries/Scoped.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/queries/Scoped.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.queries;
+
+
+import com.eventsourcing.Entity;
+import com.eventsourcing.EntityHandle;
+import com.googlecode.cqengine.attribute.Attribute;
+import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.query.Query;
+import com.googlecode.cqengine.query.option.QueryOptions;
+import com.googlecode.cqengine.query.simple.SimpleQuery;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+public class Scoped<O extends Entity> extends SimpleQuery<EntityHandle<O>, Boolean> {
+
+    @Getter
+    private final Query<EntityHandle<O>> scope;
+
+    @Getter
+    private final Query<EntityHandle<O>> query;
+
+    public Scoped(Query<EntityHandle<O>> scope, Query<EntityHandle<O>> query) {
+        super(new SimpleAttribute<EntityHandle<O>, Boolean>() {
+            @Override public Boolean getValue(EntityHandle<O> object, QueryOptions queryOptions) {
+                return false;
+            }
+        });
+        this.scope = scope;
+        this.query = query;
+    }
+
+    @Override
+    protected boolean matchesSimpleAttribute(SimpleAttribute<EntityHandle<O>, Boolean> attribute, EntityHandle<O>
+            object,
+                                             QueryOptions queryOptions) {
+        return matchesNonSimpleAttribute(attribute, object, queryOptions);
+    }
+
+    @Override
+    protected boolean matchesNonSimpleAttribute(Attribute<EntityHandle<O>, Boolean> attribute, EntityHandle<O> object,
+                                                QueryOptions queryOptions) {
+        if (!scope.matches(object, queryOptions)) {
+            return false;
+        }
+        Iterable<EntityHandle<O>> iterable = queryOptions.get(Iterable.class);
+        Map<Object, Object> options = new HashMap<>(queryOptions.getOptions());
+        options.put(Iterable.class, new FilteringIterable<>(scope, iterable, queryOptions));
+        return query.matches(object, new QueryOptions(options));
+    }
+
+    @Override protected int calcHashCode() {
+        return scope.hashCode() + 31 * query.hashCode();
+    }
+
+
+    private static class FilteringIterable<O extends Entity> implements Iterable<EntityHandle<O>> {
+        private final Query<EntityHandle<O>> scope;
+        private final Iterable<EntityHandle<O>> iterable;
+        private final QueryOptions queryOptions;
+
+        public FilteringIterable(
+                Query<EntityHandle<O>> scope, Iterable<EntityHandle<O>> iterable, QueryOptions queryOptions) {
+            this.scope = scope;
+            this.iterable = iterable;
+            this.queryOptions = queryOptions;
+        }
+
+
+        @Override public Iterator<EntityHandle<O>> iterator() {
+            return new FilteringIterator<>(this, scope, iterable, queryOptions);
+        }
+
+        private static class FilteringIterator<O extends Entity> implements Iterator<EntityHandle<O>> {
+
+            private final Query<EntityHandle<O>> scope;
+            private final Iterable<EntityHandle<O>> iterable;
+            private final QueryOptions queryOptions;
+            private Iterator<EntityHandle<O>> iterator;
+            private EntityHandle<O> next;
+
+            public FilteringIterator(FilteringIterable<O> filteringIterable, Query<EntityHandle<O>> scope,
+                                     Iterable<EntityHandle<O>> iterable, QueryOptions queryOptions) {
+                this.scope = scope;
+                this.iterable = iterable;
+                this.queryOptions = new QueryOptions(new HashMap<>(queryOptions.getOptions()));
+                this.queryOptions.put(Iterable.class, filteringIterable);
+            }
+
+            private void prepareIterator() {
+                if (iterator == null) {
+                    iterator = iterable.iterator();
+                }
+            }
+
+            @Override public boolean hasNext() {
+                prepareIterator();
+                if (!iterator.hasNext()) {
+                    next = null;
+                    return false;
+                }
+                do {
+                    next = iterator.next();
+                    if (scope.matches(next, queryOptions)) {
+                        return true;
+                    }
+                } while (iterator.hasNext());
+                next = null;
+                return false;
+            }
+
+            @Override public EntityHandle<O> next() {
+                prepareIterator();
+                if (next == null && !hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                EntityHandle<O> result = next;
+                next = null;
+                return result;
+            }
+        }
+    }
+}

--- a/eventsourcing-core/src/test/java/com/eventsourcing/queries/ScopedTest.java
+++ b/eventsourcing-core/src/test/java/com/eventsourcing/queries/ScopedTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.queries;
+
+import com.eventsourcing.*;
+import com.eventsourcing.hlc.HybridTimestamp;
+import com.eventsourcing.index.Index;
+import com.eventsourcing.index.SimpleIndex;
+import com.googlecode.cqengine.resultset.ResultSet;
+import lombok.EqualsAndHashCode;
+import lombok.SneakyThrows;
+import lombok.Value;
+import lombok.experimental.Accessors;
+import org.testng.annotations.Test;
+
+import java.util.UUID;
+
+import static com.eventsourcing.index.IndexEngine.IndexFeature.EQ;
+import static com.eventsourcing.index.IndexEngine.IndexFeature.GT;
+import static com.eventsourcing.index.IndexEngine.IndexFeature.LT;
+import static com.eventsourcing.queries.QueryFactory.*;
+import static org.testng.Assert.assertEquals;
+
+public class ScopedTest extends RepositoryUsingTest {
+
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    @Accessors(fluent = true)
+    public static class TestEvent extends StandardEvent {
+
+        String prop;
+
+        public final static SimpleIndex<TestEvent, String> PROP = SimpleIndex.as(TestEvent::prop);
+
+        @Index({EQ, LT, GT})
+        public final static SimpleIndex<TestEvent, HybridTimestamp> TIMESTAMP = SimpleIndex.as(
+                StandardEntity::timestamp);
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    @Accessors(fluent = true)
+    public static class TestCommand extends StandardCommand<UUID, HybridTimestamp> {
+
+        String prop;
+
+        @Override public EventStream<UUID> events() throws Exception {
+            TestEvent event = new TestEvent(prop);
+            return EventStream.ofWithState(event.uuid(), event);
+        }
+
+        @Override public HybridTimestamp result(UUID state, Repository repository) {
+            return repository.getJournal().get(state).get().timestamp();
+        }
+    }
+
+    public ScopedTest() {
+        super(Scoped.class.getPackage());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testScoped() {
+        HybridTimestamp ts1 = repository.publish(new TestCommand("1")).get();
+        HybridTimestamp ts2 = repository.publish(new TestCommand("2")).get();
+        HybridTimestamp ts3 = repository.publish(new TestCommand("2")).get();
+        HybridTimestamp ts4 = repository.publish(new TestCommand("3")).get();
+
+        try (ResultSet<EntityHandle<TestEvent>> rs = repository.query(TestEvent.class,
+                                                                      scoped(equal(TestEvent.PROP, "1"),
+                                                                             min(TestEvent.TIMESTAMP)))) {
+            assertEquals(rs.uniqueResult().get().timestamp(), ts1);
+        }
+
+        try (ResultSet<EntityHandle<TestEvent>> rs = repository.query(TestEvent.class,
+                                                                      scoped(equal(TestEvent.PROP, "2"),
+                                                                             min(TestEvent.TIMESTAMP)))) {
+            assertEquals(rs.uniqueResult().get().timestamp(), ts2);
+        }
+
+        try (ResultSet<EntityHandle<TestEvent>> rs = repository.query(TestEvent.class,
+                                                                      scoped(equal(TestEvent.PROP, "1"),
+                                                                             max(TestEvent.TIMESTAMP)))) {
+            assertEquals(rs.uniqueResult().get().timestamp(), ts1);
+        }
+
+        try (ResultSet<EntityHandle<TestEvent>> rs = repository.query(TestEvent.class,
+                                                                      scoped(equal(TestEvent.PROP, "2"),
+                                                                             max(TestEvent.TIMESTAMP)))) {
+            assertEquals(rs.uniqueResult().get().timestamp(), ts3);
+        }
+    }
+
+
+}

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/NavigableIndex.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/NavigableIndex.java
@@ -16,6 +16,7 @@ import com.eventsourcing.layout.SerializableComparable;
 import com.eventsourcing.layout.TypeHandler;
 import com.eventsourcing.postgresql.PostgreSQLSerialization;
 import com.eventsourcing.postgresql.PostgreSQLStatementIterator;
+import com.eventsourcing.queries.ComparingQuery;
 import com.eventsourcing.queries.Max;
 import com.eventsourcing.queries.Min;
 import com.fasterxml.classmate.ResolvedType;

--- a/examples/foodsourcing/src/test/java/foodsourcing/RestaurantTest.java
+++ b/examples/foodsourcing/src/test/java/foodsourcing/RestaurantTest.java
@@ -112,13 +112,15 @@ public class RestaurantTest extends TestWithRepository {
         Address outside = new Address("810 Quayside Dr, New Westminster, BC", "Canada", "New Westminster",
                                       "V3M 6B9", 49.200145, -122.911488);
         Restaurant kyzock = repository.publish(kyzockRegistration()).get();
+        Restaurant sushiZeroOne = repository.publish(sushiZeroOneRegistration()).get();
         repository.publish(new UpdateRestaurantAddress(kyzock, outside)).get();
-        kyzock = Restaurant.lookup(repository, kyzock.getId()).get();
+        repository.publish(new UpdateRestaurantAddress(sushiZeroOne, outside)).get();
         Collection<Restaurant> restaurants = Restaurant.query(repository, within10km(closeBy));
         assertEquals(restaurants.size(), 0);
         restaurants = Restaurant.query(repository, within10km(outside));
-        assertEquals(restaurants.size(), 1);
+        assertEquals(restaurants.size(), 2);
         assertTrue(restaurants.contains(kyzock));
+        assertTrue(restaurants.contains(sushiZeroOne));
     }
 
     @Test
@@ -148,6 +150,12 @@ public class RestaurantTest extends TestWithRepository {
         Address restaurantAddress = new Address("559 W Pender St, Vancouver, BC", "Canada", "Vancouver",
                                                 "V6B 1V5", 49.2837512, -123.1134196);
         return new RegisterRestaurant("Kyzock", restaurantAddress, new OpeningHours(11, 30, 19, 00));
+    }
+
+    private RegisterRestaurant sushiZeroOneRegistration() {
+        Address restaurantAddress = new Address("559 W Pender St, Vancouver, BC", "Canada", "Vancouver",
+                                                "V6B 1V5", 49.2837512, -123.1134196);
+        return new RegisterRestaurant("Sushi Zero One", restaurantAddress, new OpeningHours(11, 30, 19, 00));
     }
 
 


### PR DESCRIPTION
Min/Max queries are limited to finding the smallest or largest value of a
particular attribute globally across an entity. Which means you can tell
"what's the latest order" but not "what's the latest order for this person".
IsLatestEntity/LatestAssociatedEntryQuery are currently being used to address
this type of need, but they are very slow and cumbersome. Min/Max has been
already optimized for PostgreSQL storage.

Solution: introduce Scoped query to provide a different scope to a subquery:

```java
scoped(equal(Product.ID, id), max(Product.TIMESTAMP))
````

(It looks like even without backend-specific optimizations,
this query is a lot faster than `IsLatestEntity`)

Addresses #209