### PR TITLE
Problem: Postgres backend runs out of memory

### DIFF
--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/PostgreSQLJournal.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/PostgreSQLJournal.java
@@ -44,6 +44,7 @@ import static com.eventsourcing.postgresql.PostgreSQLSerialization.*;
 @Component(property = "type=PostgreSQLJournal", service = Journal.class)
 public class PostgreSQLJournal extends AbstractService implements Journal {
 
+    public static final int MAX_FETCH_SIZE = 10_000;
     @Reference
     protected DataSourceProvider dataSourceProvider;
 
@@ -268,6 +269,7 @@ public class PostgreSQLJournal extends AbstractService implements Journal {
 
         if (!eagerFetching) {
             PreparedStatement s = connection.prepareStatement("SELECT uuid FROM layout_v1_" + hash);
+            s.setFetchSize(MAX_FETCH_SIZE);
             return new EntityIterator<>(this, s, connection);
         } else {
             ReaderFunction reader = readerFunctions.get(hash);
@@ -276,6 +278,7 @@ public class PostgreSQLJournal extends AbstractService implements Journal {
                                                         .map(p -> "\"" + p.getName() + "\"").collect(Collectors.toList()));
             String query = "SELECT " + columns + ", uuid AS ___uuid___ FROM layout_v1_" + hash;
             PreparedStatement s = connection.prepareStatement(query);
+            s.setFetchSize(MAX_FETCH_SIZE);
             return new EagerEntityIterator<>(this, s, connection, reader);
         }
     }

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/PostgreSQLStatementIterator.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/PostgreSQLStatementIterator.java
@@ -41,6 +41,12 @@ public abstract class PostgreSQLStatementIterator<T> implements CloseableIterato
             resultSet = statement.executeQuery();
         }
 
+        // if the result set is already closed,
+        // there are no more results to expect
+        if (resultSet.isClosed()) {
+            return false;
+        }
+
         if (nextCalled) {
             nextCalled = false;
             if (resultSet.next()) {


### PR DESCRIPTION
Problem: when fetching large datasets, pgsql driver runs out of memory
Solution: set fetch size at 10,000 rows

Problem: large additions to pgsql index run out of memory
Solution: manually form batches of up to 1000 records