### PR TITLE
Problem: reindexing large datasets is very time consuming

### DIFF
--- a/eventsourcing-core/src/main/java/com/eventsourcing/Journal.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/Journal.java
@@ -8,15 +8,19 @@
 package com.eventsourcing;
 
 import com.eventsourcing.hlc.HybridTimestamp;
+import com.eventsourcing.queries.QueryFactory;
 import com.eventsourcing.utils.CloseableWrappingIterator;
 import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.Service;
 import com.googlecode.cqengine.index.support.CloseableIterator;
+import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.SneakyThrows;
 
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+
+import static com.eventsourcing.queries.QueryFactory.noQueryOptions;
 
 /**
  * Journal is the storage of all events and commands registered
@@ -60,7 +64,7 @@ public interface Journal extends Service {
      * @return iterator
      */
     default <T extends Command<?, ?>> CloseableIterator<EntityHandle<T>> commandIterator(Class<T> klass) {
-        return new CloseableWrappingIterator<>(Collections.emptyIterator());
+        return commandIterator(klass, noQueryOptions());
     }
 
     /**
@@ -71,7 +75,7 @@ public interface Journal extends Service {
      * @return iterator
      */
     default <T extends Event> CloseableIterator<EntityHandle<T>> eventIterator(Class<T> klass) {
-        return new CloseableWrappingIterator<>(Collections.emptyIterator());
+        return eventIterator(klass, noQueryOptions());
     }
 
     /**
@@ -81,10 +85,8 @@ public interface Journal extends Service {
      * @param <T>
      * @return iterator
      */
-    default <T extends Command<?, ?>> CloseableIterator<EntityHandle<T>> commandIterator(Class<T> klass, boolean
-            eagerFetching) {
-        return commandIterator(klass);
-    }
+    <T extends Command<?, ?>> CloseableIterator<EntityHandle<T>> commandIterator(Class<T> klass,
+                                                                                 QueryOptions queryOptions);
 
     /**
      * Iterate over events of a specific type (through {@code EntityHandler<T>})
@@ -93,9 +95,7 @@ public interface Journal extends Service {
      * @param <T>
      * @return iterator
      */
-    default <T extends Event> CloseableIterator<EntityHandle<T>> eventIterator(Class<T> klass, boolean eagerFetching) {
-        return eventIterator(klass);
-    }
+    <T extends Event> CloseableIterator<EntityHandle<T>> eventIterator(Class<T> klass, QueryOptions queryOptions);
 
     /**
      * Removes everything from the journal.

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/CommandJournalPersistence.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/CommandJournalPersistence.java
@@ -10,6 +10,7 @@ package com.eventsourcing.index;
 import com.eventsourcing.Command;
 import com.eventsourcing.EntityHandle;
 import com.eventsourcing.Journal;
+import com.eventsourcing.queries.options.EagerFetching;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.support.CloseableIterator;
 import com.googlecode.cqengine.persistence.support.ObjectStore;
@@ -48,7 +49,7 @@ public class CommandJournalPersistence<T extends Command<?, ?>> extends JournalP
 
         @Override
         public CloseableIterator<EntityHandle<T>> iterator(QueryOptions queryOptions) {
-            return journal.commandIterator(klass, queryOptions.get(EagerFetching.class) != null);
+            return journal.commandIterator(klass, queryOptions);
         }
     }
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/EventJournalPersistence.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/EventJournalPersistence.java
@@ -10,6 +10,7 @@ package com.eventsourcing.index;
 import com.eventsourcing.EntityHandle;
 import com.eventsourcing.Event;
 import com.eventsourcing.Journal;
+import com.eventsourcing.queries.options.EagerFetching;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.support.CloseableIterator;
 import com.googlecode.cqengine.persistence.support.ObjectStore;
@@ -49,7 +50,7 @@ public class EventJournalPersistence<T extends Event> extends JournalPersistence
 
         @Override
         public CloseableIterator<EntityHandle<T>> iterator(QueryOptions queryOptions) {
-            return journal.eventIterator(klass, queryOptions.get(EagerFetching.class) != null);
+            return journal.eventIterator(klass, queryOptions);
         }
     }
 }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/index/JournalPersistence.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/index/JournalPersistence.java
@@ -73,9 +73,6 @@ public abstract class JournalPersistence<T extends Entity> implements Persistenc
         }
 
         @Override
-        public abstract CloseableIterator<EntityHandle<T>> iterator(QueryOptions queryOptions);
-
-        @Override
         public boolean add(EntityHandle<T> tEntityHandle, QueryOptions queryOptions) {
             return true; // this is taken care of with journalling
         }

--- a/eventsourcing-core/src/main/java/com/eventsourcing/queries/options/EagerFetching.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/queries/options/EagerFetching.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.queries.options;
+
+import com.googlecode.cqengine.query.option.QueryOptions;
+
+/**
+ * EagerFetching is a {@link QueryOptions} query option that signals to the indexing subsystem to eagerly fetch entities
+ * if possible. Useful when iterating over the entire journal and processing the entire batch.
+ */
+public final class EagerFetching {
+}

--- a/eventsourcing-core/src/main/java/com/eventsourcing/queries/options/NotSeenBy.java
+++ b/eventsourcing-core/src/main/java/com/eventsourcing/queries/options/NotSeenBy.java
@@ -5,13 +5,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.eventsourcing.index;
+package com.eventsourcing.queries.options;
 
 import com.googlecode.cqengine.query.option.QueryOptions;
+import lombok.Value;
 
 /**
- * EagerFetching is a {@link QueryOptions} query option that signals to the indexing subsystem to eagerly fetch entities
- * if possible. Useful when iterating over the entire journal and processing the entire batch.
+ * This {@link QueryOptions} query option allows to optimize
+ * iterating over the journal in special circumstances, like an index
+ * that doesn't want to reindex what already has been indexed.
  */
-public final class EagerFetching {
+@Value
+public class NotSeenBy {
+    byte[] id;
 }

--- a/eventsourcing-inmem/src/main/java/com/eventsourcing/inmem/MemoryJournal.java
+++ b/eventsourcing-inmem/src/main/java/com/eventsourcing/inmem/MemoryJournal.java
@@ -17,6 +17,7 @@ import com.eventsourcing.utils.CloseableWrappingIterator;
 import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.AbstractService;
 import com.googlecode.cqengine.index.support.CloseableIterator;
+import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Getter;
 import lombok.Setter;
 import org.osgi.service.component.annotations.Component;
@@ -126,7 +127,7 @@ public class MemoryJournal extends AbstractService implements Journal {
     }
 
     @Override
-    public <T extends Command<?, ?>> CloseableIterator<EntityHandle<T>> commandIterator(Class<T> klass) {
+    public <T extends Command<?, ?>> CloseableIterator<EntityHandle<T>> commandIterator(Class<T> klass, QueryOptions queryOptions) {
         return new CloseableWrappingIterator<>(commands.values().stream()
                                                        .filter(command -> klass.isAssignableFrom(command.getClass()))
                                                        .map(command -> (EntityHandle<T>) new JournalEntityHandle<T>(
@@ -134,7 +135,7 @@ public class MemoryJournal extends AbstractService implements Journal {
     }
 
     @Override
-    public <T extends Event> CloseableIterator<EntityHandle<T>> eventIterator(Class<T> klass) {
+    public <T extends Event> CloseableIterator<EntityHandle<T>> eventIterator(Class<T> klass, QueryOptions queryOptions) {
         return new CloseableWrappingIterator<>(events.values().stream()
                                                      .filter(event -> klass.isAssignableFrom(event.getClass()))
                                                      .map(event -> (EntityHandle<T>) new JournalEntityHandle<T>(this,

--- a/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/PostgreSQLAttributeIndex.java
+++ b/eventsourcing-postgresql/src/main/java/com/eventsourcing/postgresql/index/PostgreSQLAttributeIndex.java
@@ -17,6 +17,8 @@ import com.eventsourcing.layout.SerializableComparable;
 import com.eventsourcing.layout.TypeHandler;
 import com.eventsourcing.postgresql.PostgreSQLSerialization;
 import com.eventsourcing.postgresql.PostgreSQLStatementIterator;
+import com.eventsourcing.queries.options.EagerFetching;
+import com.eventsourcing.queries.options.NotSeenBy;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.support.*;
 import com.googlecode.cqengine.index.unique.UniqueIndex;
@@ -257,10 +259,6 @@ public abstract class PostgreSQLAttributeIndex<A, O extends Entity> extends Abst
         return attribute;
     }
 
-    protected void addAll(ObjectStore<EntityHandle<O>> objectStore, QueryOptions queryOptions) {
-        addAll(objectStore.iterator(queryOptions), queryOptions);
-    }
-
     @SneakyThrows
     @Override public boolean removeAll(ObjectSet<EntityHandle<O>> objects, QueryOptions queryOptions) {
         try(Connection connection = getDataSource().getConnection()) {
@@ -299,7 +297,8 @@ public abstract class PostgreSQLAttributeIndex<A, O extends Entity> extends Abst
         }
         queryOptions.put(OnConflictDo.class, OnConflictDo.NOTHING);
         queryOptions.put(EagerFetching.class, true);
-        addAll(objectStore, queryOptions);
+        queryOptions.put(NotSeenBy.class, new NotSeenBy(getTableName().getBytes()));
+        addAll(objectStore.iterator(queryOptions), queryOptions);
     }
 
     @SneakyThrows


### PR DESCRIPTION
Upon index initialization, index has no idea if the object
store's data has been indexed.

Solution: in PostgreSQL-backed journal, assign sequential
IDs to entities and introduce the use of NotSeenBy query option
to avoid reindexing